### PR TITLE
cleanup rat module and remove checks for ancient GDAL versions

### DIFF
--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -29,12 +29,6 @@ from distutils.version import LooseVersion
 from . import cuiprogress
 from .rioserrors import ProcessCancelledError
 
-# Test whether we have access to the GDAL RFC40 facilities
-haveRFC40 = False
-if (os.getenv('RIOS_HISTOGRAM_IGNORE_RFC40') is None and 
-        hasattr(gdal.RasterAttributeTable, 'ReadAsArray')):
-    haveRFC40 = True
-
 # test if https://trac.osgeo.org/gdal/ticket/6854 has been fixed
 # this allows us to use the rat.SetLinearBinning call rather than metadata
 if hasattr(gdal, '__version__'):
@@ -291,7 +285,7 @@ def addStatistics(ds,progress,ignore=None, approx_ok=False):
             else:
                 tmpmeta["STATISTICS_MODE"] = repr(int(round(modeval)))
 
-            if haveRFC40 and ratObj is not None:
+            if ratObj is not None:
                 histIndx, histNew = findOrCreateColumn(ratObj, gdal.GFU_PixelCount, 
                                         "Histogram", gdal.GFT_Real)
                 # write the hist in a single go
@@ -334,7 +328,7 @@ def addStatistics(ds,progress,ignore=None, approx_ok=False):
         # set the data
         band.SetMetadata(tmpmeta)
 
-        if haveRFC40 and ratObj is not None and not ratObj.ChangesAreWrittenToFile():
+        if ratObj is not None and not ratObj.ChangesAreWrittenToFile():
             # For drivers that require the in memory thing
             band.SetDefaultRAT(ratObj)
 

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -29,14 +29,6 @@ from distutils.version import LooseVersion
 from . import cuiprogress
 from .rioserrors import ProcessCancelledError
 
-# test if https://trac.osgeo.org/gdal/ticket/6854 has been fixed
-# this allows us to use the rat.SetLinearBinning call rather than metadata
-if hasattr(gdal, '__version__'):
-    # Fail slightly less drastically when running from ReadTheDocs
-    haveLinearBinningFix = LooseVersion(gdal.__version__) >= LooseVersion('2.2.0')
-else:
-    haveLinearBinningFix = False
-
 # When calculating overviews (i.e. pyramid layers), default behaviour
 # is controlled by these
 dfltOverviewLvls = os.getenv('RIOS_DFLT_OVERVIEWLEVELS')
@@ -292,14 +284,7 @@ def addStatistics(ds,progress,ignore=None, approx_ok=False):
                 ratObj.SetRowCount(histnbins)
                 ratObj.WriteArray(hist, histIndx)
 
-                # Use SetLinearBinning function if it has been fixed
-                # in the current version of GDAL
-                if haveLinearBinningFix:
-                    ratObj.SetLinearBinning(histmin, (histCalcMax - histCalcMin) / histnbins)
-                else:
-                    tmpmeta["STATISTICS_HISTOMIN"] = repr(histmin)
-                    tmpmeta["STATISTICS_HISTOMAX"] = repr(histmax)
-                    tmpmeta["STATISTICS_HISTONUMBINS"] = repr(histnbins)
+                ratObj.SetLinearBinning(histmin, (histCalcMax - histCalcMin) / histnbins)
 
                 # The HFA driver still honours the STATISTICS_HISTOBINVALUES
                 # metadata item. If we are recalculating the histogram the old

--- a/rios/imagewriter.py
+++ b/rios/imagewriter.py
@@ -423,32 +423,25 @@ class ImageWriter(object):
         imgInfo = fileinfo.ImageInfo(self.filename)
         if imgInfo.layerType == "thematic":
             imgStats = fileinfo.ImageFileStats(self.filename)
-            ds = None
-            if calcstats.haveRFC40:
-                ds = gdal.Open(self.filename, gdal.GA_Update)
+            ds = gdal.Open(self.filename, gdal.GA_Update)
 
             for i in range(imgInfo.rasterCount):
                 numEntries = imgStats[i].max + 1
                 clrTbl = rat.genColorTable(numEntries, autoColorTableType)
-                if not calcstats.haveRFC40:
-                    rat.setColorTable(self.filename, clrTbl, layernum=i+1)
-                else:
-                    # If we have the RFC40 facilities, then use them to write the colour table, 
-                    # because otherwise Sam will get cross with me. 
-                    band = ds.GetRasterBand(i+1)
-                    ratObj = band.GetDefaultRAT()
-                    redIdx, redNew = calcstats.findOrCreateColumn(ratObj, gdal.GFU_Red, "Red", gdal.GFT_Integer)
-                    greenIdx, greenNew = calcstats.findOrCreateColumn(ratObj, gdal.GFU_Green, "Green", gdal.GFT_Integer)
-                    blueIdx, blueNew = calcstats.findOrCreateColumn(ratObj, gdal.GFU_Blue, "Blue", gdal.GFT_Integer)
-                    alphaIdx, alphaNew = calcstats.findOrCreateColumn(ratObj, gdal.GFU_Alpha, "Alpha", gdal.GFT_Integer)
-                    # were any of these not already existing?
-                    if redNew or greenNew or blueNew or alphaNew:
-                        ratObj.WriteArray(clrTbl[:, 0], redIdx)
-                        ratObj.WriteArray(clrTbl[:, 1], greenIdx)
-                        ratObj.WriteArray(clrTbl[:, 2], blueIdx)
-                        ratObj.WriteArray(clrTbl[:, 3], alphaIdx)
-                    if not ratObj.ChangesAreWrittenToFile():
-                        band.SetDefaultRAT(ratObj)
+                band = ds.GetRasterBand(i+1)
+                ratObj = band.GetDefaultRAT()
+                redIdx, redNew = calcstats.findOrCreateColumn(ratObj, gdal.GFU_Red, "Red", gdal.GFT_Integer)
+                greenIdx, greenNew = calcstats.findOrCreateColumn(ratObj, gdal.GFU_Green, "Green", gdal.GFT_Integer)
+                blueIdx, blueNew = calcstats.findOrCreateColumn(ratObj, gdal.GFU_Blue, "Blue", gdal.GFT_Integer)
+                alphaIdx, alphaNew = calcstats.findOrCreateColumn(ratObj, gdal.GFU_Alpha, "Alpha", gdal.GFT_Integer)
+                # were any of these not already existing?
+                if redNew or greenNew or blueNew or alphaNew:
+                    ratObj.WriteArray(clrTbl[:, 0], redIdx)
+                    ratObj.WriteArray(clrTbl[:, 1], greenIdx)
+                    ratObj.WriteArray(clrTbl[:, 2], blueIdx)
+                    ratObj.WriteArray(clrTbl[:, 3], alphaIdx)
+                if not ratObj.ChangesAreWrittenToFile():
+                    band.SetDefaultRAT(ratObj)
 
     def doubleCheckCreationOptions(self, drivername, creationoptions):
         """

--- a/rios/imagewriter.py
+++ b/rios/imagewriter.py
@@ -426,7 +426,7 @@ class ImageWriter(object):
             ds = gdal.Open(self.filename, gdal.GA_Update)
 
             for i in range(imgInfo.rasterCount):
-                numEntries = imgStats[i].max + 1
+                numEntries = int(imgStats[i].max + 1)
                 clrTbl = rat.genColorTable(numEntries, autoColorTableType)
                 band = ds.GetRasterBand(i+1)
                 ratObj = band.GetDefaultRAT()

--- a/rios/inputcollection.py
+++ b/rios/inputcollection.py
@@ -319,9 +319,8 @@ class InputCollection(object):
         # as a list for subprocess - also a bit easier to read
         cmdList = [gdalwarp_path]
         
-        if LooseVersion(gdal.__version__) >= LooseVersion('2.0'):
-            if not allowOverviewsGdalwarp:
-                cmdList.extend(['-ovr', 'NONE'])
+        if not allowOverviewsGdalwarp:
+            cmdList.extend(['-ovr', 'NONE'])
         
         # source projection prf file
         cmdList.append('-s_srs')

--- a/rios/rat.py
+++ b/rios/rat.py
@@ -304,16 +304,17 @@ def getColorTable(imgFile, bandNumber=1):
         ds = imgFile
 
     gdalBand = ds.GetRasterBand(bandNumber)
+    colorTable = gdalBand.GetColorTable()
+    if colorTable is None:
+        raise rioserrors.AttributeTableColumnError("Image has no color table")
 
-    colorList = []
-    for name in ["Red", "Green", "Blue", "Alpha"]:
-        data = readColumnFromBand(name)
-        colorList.append(data)
-        
-    count = colorList[0].size
-    colorArray = numpy.empty((count, 4), dtype=numpy.int)
-    for n in range(len(colorList)):
-        colorArray[:, n] = colorList[n]
+    count = colorTable.GetCount()
+    # count could be any size so we have to go with int
+    colorArray = numpy.zeros((count, 5), dtype=numpy.int)
+    for index in range(count):
+        colorEntry = colorTable.GetColorEntry(index)
+        arrayEntry = [index] + list(colorEntry)
+        colorArray[index] = numpy.array(arrayEntry)
 
     return colorArray
 
@@ -324,18 +325,26 @@ def setColorTable(imgfile, colorTblArray, layernum=1):
     the imgfile as either a filename string or a gdal.Dataset object. The
     layer number defaults to 1, i.e. the first layer in the file. 
     
-    The color table is given as a numpy array of 4 columns. There is one row 
+    The color table is given as a numpy array of 5 columns. There is one row 
     (i.e. first array index) for every value to be set, and the columns
     are:
-
+        * pixelValue
         * Red
         * Green
         * Blue
         * Opacity
-
     The Red/Green/Blue values are on the range 0-255, with 255 meaning full 
     color, and the opacity is in the range 0-255, with 255 meaning fully 
     opaque. 
+    
+    The pixels values in the first column must be in ascending order, but do 
+    not need to be a complete set (i.e. you don't need to supply a color for 
+    every possible pixel value - any not given will default to transparent black).
+    It does not even need to be contiguous. 
+    
+    For reasons of backwards compatability, a 4-column array will also be accepted, 
+    and will be treated as though the row index corresponds to the pixelValue (i.e. 
+    starting at zero). 
     
     """
     arrayShape = colorTblArray.shape
@@ -343,8 +352,15 @@ def setColorTable(imgfile, colorTblArray, layernum=1):
         raise rioserrors.ArrayShapeError("ColorTableArray must be 2D. Found shape %s instead"%arrayShape)
         
     (numRows, numCols) = arrayShape
-    if numCols != 4:
-        raise rioserrors.ArrayShapeError("Color table array has %d columns, expecting 4"%numCols)
+    # Handle the backwards-compatible case of a 4-column array
+    if numCols == 4:
+        pixVals = numpy.arange(numRows)
+        colorTbl4cols = colorTblArray
+    elif numCols == 5:
+        pixVals = colorTblArray[:, 0]
+        colorTbl4cols = colorTblArray[:, 1:]
+    else:
+        raise rioserrors.ArrayShapeError("Color table array has %d columns, expecting 4 or 5"%numCols)
     
     # Open the image file and get the band object
     if isinstance(imgfile, gdal.Dataset):
@@ -354,15 +370,32 @@ def setColorTable(imgfile, colorTblArray, layernum=1):
     
     bandobj = ds.GetRasterBand(layernum)
     
-    writeColumnToBand(bandobj, "Red", colorTblArray[:, 0], 
-                gdal.GFT_Integer, gdal.GFU_Red)
-    writeColumnToBand(bandobj, "Green", colorTblArray[:, 0], 
-                gdal.GFT_Integer, gdal.GFU_Green)
-    writeColumnToBand(bandobj, "Blue", colorTblArray[:, 0], 
-                gdal.GFT_Integer, gdal.GFU_Blue)
-    writeColumnToBand(bandobj, "Alpha", colorTblArray[:, 0], 
-                gdal.GFT_Integer, gdal.GFU_Alpha)
+    clrTbl = gdal.ColorTable()
+    maxPixVal = pixVals.max()
+    i = 0
+    # This loop sets an entry for every pixel value up to the largest given. Imagine
+    # bitches if we don't do this. 
+    tblMaxVal = maxPixVal
+    if bandobj.DataType == gdal.GDT_Byte:
+        # For Byte files, we always add rows for entries up to 255. Imagine gets 
+        # confused if we don't
+        tblMaxVal = 255
+        
+    for pixVal in range(tblMaxVal+1):
+        while  i < numRows and pixVals[i] < pixVal:
+            i += 1
+        if i < numRows:
+            tblPixVal = pixVals[i]
+            if tblPixVal == pixVal:
+                colEntry = tuple(colorTbl4cols[i])
+            else:
+                colEntry = (0, 0, 0, 0)
+        else:
+            colEntry = (0, 0, 0, 0)
+        clrTbl.SetColorEntry(pixVal, colEntry)
     
+    bandobj.SetRasterColorTable(clrTbl)
+        
 def genColorTable(numEntries, colortype):
     """
     Generate a colour table array. The type of colour table generated

--- a/rios/rat.py
+++ b/rios/rat.py
@@ -328,11 +328,13 @@ def setColorTable(imgfile, colorTblArray, layernum=1):
     The color table is given as a numpy array of 5 columns. There is one row 
     (i.e. first array index) for every value to be set, and the columns
     are:
+    
         * pixelValue
         * Red
         * Green
         * Blue
         * Opacity
+        
     The Red/Green/Blue values are on the range 0-255, with 255 meaning full 
     color, and the opacity is in the range 0-255, with 255 meaning fully 
     opaque. 
@@ -395,6 +397,7 @@ def setColorTable(imgfile, colorTblArray, layernum=1):
         clrTbl.SetColorEntry(pixVal, colEntry)
     
     bandobj.SetRasterColorTable(clrTbl)
+
         
 def genColorTable(numEntries, colortype):
     """

--- a/rios/rat.py
+++ b/rios/rat.py
@@ -32,13 +32,6 @@ from osgeo import gdal
 import numpy
 from . import rioserrors
 
-# use turborat if available
-try:
-    from turbogdal import turborat
-    HAVE_TURBORAT = True
-except ImportError:
-    HAVE_TURBORAT = False
-
 if sys.version_info[0] > 2:
     # hack for Python 3 which uses str instead of basestring
     # we just use basestring
@@ -74,48 +67,9 @@ def readColumnFromBand(gdalBand, colName):
     # loop thru the columns looking for the right one
     for col in range(numCols):
         if rat.GetNameOfCol(col) == colName:
-            # found it - create the output array
-            # and fill in the values
+            # found it - read the values
 
-            # use RFC40 function if available
-            if hasattr(rat, "ReadAsArray"):
-                colArray = rat.ReadAsArray(col)
-
-            elif HAVE_TURBORAT:
-                # if turborat is available use that
-                colArray = turborat.readColumn(rat, col)
-            else:
-                # do it the slow way
-                dtype = rat.GetTypeOfCol(col)
-                if dtype == gdal.GFT_Integer:
-                    colArray = numpy.zeros(numRows,int)
-                elif dtype == gdal.GFT_Real:
-                    colArray = numpy.zeros(numRows,float)
-                elif dtype == gdal.GFT_String:
-                    # for string attributes, create a list - convert later
-                    colArray = []
-                else:
-                    msg = "Can't interpret data type of attribute"
-                    raise rioserrors.AttributeTableTypeError(msg)
-            
-        
-                # do it checking the type outside the loop for maximum speed
-                if dtype == gdal.GFT_Integer:
-                    for row in range(numRows):
-                        val = rat.GetValueAsInt(row,col)
-                        colArray[row] = val
-                elif dtype == gdal.GFT_Real:
-                    for row in range(numRows):
-                        val = rat.GetValueAsDouble(row,col)
-                        colArray[row] = val
-                else:
-                    for row in range(numRows):
-                        val = rat.GetValueAsString(row,col)
-                        colArray.append(val)
-
-                if isinstance(colArray, list):
-                    # convert to array - numpy can handle this now it can work out the lengths
-                    colArray = numpy.array(colArray)
+            colArray = rat.ReadAsArray(col)
 
             # one last little hack - if is a colour column, but type
             # was float, multiply by 255. This is so that HFA etc that stores values
@@ -222,30 +176,20 @@ def writeColumnToBand(gdalBand, colName, sequence, colType=None,
         msg = "coltype must be a valid gdal column type"
         raise rioserrors.AttributeTableTypeError(msg)
 
-    # things get a bit weird here as we need different
-    # behaviour depending on whether we have an RFC40
-    # RAT or not.
-    if hasattr(gdal.RasterAttributeTable, "WriteArray"):
-        # new behaviour
-        attrTbl = gdalBand.GetDefaultRAT()
-        if attrTbl is None:
-            # some formats eg ENVI return None
-            # here so we need to be able to cope
-            attrTbl = gdal.RasterAttributeTable()
-            isFileRAT = False
-        else:
-
-            isFileRAT = True
-
-            # but if it doesn't support dynamic writing
-            # we still ahve to call SetDefaultRAT
-            if not attrTbl.ChangesAreWrittenToFile():
-                isFileRAT = False
-
-    else:
-        # old behaviour
+    attrTbl = gdalBand.GetDefaultRAT()
+    if attrTbl is None:
+        # some formats eg ENVI return None
+        # here so we need to be able to cope
         attrTbl = gdal.RasterAttributeTable()
         isFileRAT = False
+    else:
+
+        isFileRAT = True
+
+        # but if it doesn't support dynamic writing
+        # we still ahve to call SetDefaultRAT
+        if not attrTbl.ChangesAreWrittenToFile():
+            isFileRAT = False
 
     # thanks to RFC40 we need to ensure colname doesn't already exist
     colExists = False
@@ -268,8 +212,6 @@ def writeColumnToBand(gdalBand, colName, sequence, colType=None,
     # color table handling.
     # we assume that the column has already been created
     # of the right type appropriate for the format (maybe by calcstats)
-    # Note: this only works post RFC40 when we have an actual reference
-    # to the RAT rather than a new one so we can ask GetTypeOfCol
     usage = attrTbl.GetUsageOfCol(colNum)
     if (isColorColFromUsage(usage) and 
             attrTbl.GetTypeOfCol(colNum) == gdal.GFT_Real and
@@ -277,48 +219,8 @@ def writeColumnToBand(gdalBand, colName, sequence, colType=None,
         sequence = numpy.array(sequence, dtype=numpy.float)
         sequence = sequence / 255.0
 
-    if hasattr(attrTbl, "WriteArray"):
-        # if GDAL > 1.10 has these functions
-        # thanks to RFC40
-        attrTbl.SetRowCount(rowsToAdd)
-        attrTbl.WriteArray(sequence, colNum)
-
-    elif HAVE_TURBORAT:
-        # use turborat to write values to RAT if available
-        if not isinstance(sequence, numpy.ndarray):
-            # turborat.writeColumn needs an array
-            sequence = numpy.array(sequence)
-            
-        # If the dtype of the array is some unicode type, then convert to simple string type,
-        # as turborat does not cope with the unicode variant. 
-        if 'U' in str(sequence.dtype):
-            sequence = sequence.astype(numpy.character)
-            
-        turborat.writeColumn(attrTbl, colNum, sequence, rowsToAdd)
-    else:
-        defaultValues = {gdal.GFT_Integer:0, gdal.GFT_Real:0.0, gdal.GFT_String:''}
-
-        # go thru and set each value into the RAT
-        for rowNum in range(rowsToAdd):
-            if rowNum >= len(sequence):
-                # they haven't given us enough values - fill in with default
-                val = defaultValues[colType]
-            else:
-                val = sequence[rowNum]
-
-            if colType == gdal.GFT_Integer:
-                # appears that swig cannot convert numpy.int64
-                # to the int type required by SetValueAsInt
-                # so we need to cast. 
-                # This is a problem as readColumn returns numpy.int64 
-                # for integer columns. 
-                # Seems fine converting numpy.float64 to 
-                # float however for SetValueAsDouble.
-                attrTbl.SetValueAsInt(rowNum, colNum, int(val))
-            elif colType == gdal.GFT_Real:
-                attrTbl.SetValueAsDouble(rowNum, colNum, float(val))
-            else:
-                attrTbl.SetValueAsString(rowNum, colNum, val)
+    attrTbl.SetRowCount(rowsToAdd)
+    attrTbl.WriteArray(sequence, colNum)
 
     if not isFileRAT:
         # assume existing bands re-written

--- a/rios/vectorreader.py
+++ b/rios/vectorreader.py
@@ -82,19 +82,6 @@ class Vector(object):
             if fieldidx == -1:
                 raise rioserrors.VectorAttributeError("Attribute does not exist in file: %s" % attribute)
 
-        # check they have passed a polygon type
-        validtypes = [ogr.wkbMultiPolygon,ogr.wkbMultiPolygon25D,ogr.wkbPolygon,ogr.wkbPolygon25D]
-        if layerdefn.GetGeomType() not in validtypes:
-            gdalVersion = None
-            if hasattr(gdal, '__version__'):
-                gdalVersion = gdal.__version__
-            # This seems to be the only way to reliably deal with 
-            # GDAL 1.10.0 < 1.9.0 comparisons...
-            from distutils.version import LooseVersion
-            if gdalVersion is None or LooseVersion(gdalVersion) < LooseVersion('1.9.0'):
-                raise rioserrors.VectorGeometryTypeError("Can only rasterize polygon types "+
-                    "with this version of gdal. Need gdal version >= 1.9.0")
-
         # apply the attribute filter if passed
         if filter is not None:
             self.layer.SetAttributeFilter(filter)     


### PR DESCRIPTION
This PR attempts to tidy up the parts of the code that deal with pre-rfc40 (https://gdal.org/development/rfc/rfc40_enhanced_rat_support.html) versions of GDAL. Since this was introduced in GDAL 2.0 we feel that we no longer need to handle this.

As a result the color table code can use the new RAT reading and writing routines and these will be much faster for large color tables. 

Things still to do on this PR:

- Remove GDAL version checks elsewhere in the code - all seem to be for bugs that have been fixed ages ago.
- Resolve what to do with `calcstatc.findOrCreateColumn()` - should this live in the `rat` module?
- Decide whether the color table array axes should be reversed - seems a bit clunky the way it is
- Bring in color ramps from https://colorbrewer2.org by copying over the code in TuiView
- test