### PR TITLE
add option to specify where the points on the color ramp are

### DIFF
--- a/rios/colortable.py
+++ b/rios/colortable.py
@@ -307,7 +307,7 @@ def getRampNames():
     names.append(RANDOM_NAME)
     return names
 
-def genTable(numEntries, colorType, ignoreVal=None):
+def genTable(numEntries, colorType, ignoreVal=None, colorPoints=None):
     """
     Generate the named color table for use with setTable().
     
@@ -322,6 +322,11 @@ def genTable(numEntries, colorType, ignoreVal=None):
     row is set to 0 - ie totally transparent. Use this for
     preparing images for display so images underneath in a 
     viewer show through where the ignoreVal is set.
+    
+    If colorPoints is set it should be a sequence of entry numbers
+    to use for the points on the color ramp. If not given the points
+    on the color ramp are evenly spread 0-numEntries. Actual colors
+    for points between are interpolated.
 
     The returned colour table is a numpy array, described in detail
     in the docstring for colortable.setTable(). 
@@ -346,14 +351,21 @@ def genTable(numEntries, colorType, ignoreVal=None):
             # turn it into a list of floats
             # numpy.interp() needs floats
             colList = [float(x) for x in colstr.split()]
-            # the x-values of the observations
-            # evenly spaced 0-255 with len(colList) obs
-            xobs = numpy.linspace(0, 255, len(colList))
+            if colorPoints is not None:
+                # use what they've given us
+                if len(colorPoints) != len(colList):
+                    msg = 'colorPoints needs to have same number as selected ramp'
+                    raise ColorTableException(msg)
+                xobs = colorPoints
+            else:
+                # the x-values of the observations
+                # evenly spaced 0-numEntries with len(colList) obs
+                xobs = numpy.linspace(0, numEntries, len(colList))
             # create an array from our list
             yobs = numpy.array(colList)
-            # values to interpolate at 0-255
+            # values to interpolate at 0-numEntries
             # same size as the lut
-            xinterp = numpy.linspace(0, 255, numEntries)
+            xinterp = numpy.linspace(0, numEntries, numEntries)
             # do the interp
             yinterp = numpy.interp(xinterp, xobs, yobs)
             # put into color table


### PR DESCRIPTION
Default behaviour is still to spread out the ramp evenly over the number of entries. This allows you to specify where the points on the colour ramp our so you can "stretch" the ramp to better suit your data.

Also fix issues with non-256 length color tables (stupid error copying from TuiView which always has 256 color tables internally).