### PR TITLE
use numpy.distutils for install instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with Python.
 
 import os
 import sys
-from distutils.core import setup
+from setuptools import setup
 import glob
 
 import rios

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with Python.
 
 import os
 import sys
-from setuptools import setup
+from numpy.distutils.core import setup
 import glob
 
 import rios


### PR DESCRIPTION
`distutils` is now deprecated and will be removed in Python 3.12 (https://www.python.org/dev/peps/pep-0632/). Since Python 3.10 users will get a warning when they install `rios` as `setup.py` is still using it.

Given the long breaks between `rios` releases, it might be good to get this change in sooner rather than later.

`setuptools` does have some differences from `distutils`. In particular it installs in `egg` format by default. To get behaviour similar to `distutils` use:
```
python setup.py install --single-version-externally-managed --record=record.txt
```