### PR TITLE
try and keep flake8 happy by tidying the code

### DIFF
--- a/rios/parallel/cloudpickle.py
+++ b/rios/parallel/cloudpickle.py
@@ -43,7 +43,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 from __future__ import print_function
 
 import dis
-from functools import partial
 import io
 import itertools
 import logging
@@ -53,7 +52,6 @@ import pickle
 import platform
 import struct
 import sys
-import traceback
 import types
 import weakref
 import uuid

--- a/rios/parallel/jobmanager.py
+++ b/rios/parallel/jobmanager.py
@@ -103,9 +103,7 @@ from __future__ import print_function
 
 import os
 import sys
-import math
 import abc
-import copy
 import subprocess
 import tempfile
 import time
@@ -113,8 +111,6 @@ try:
     import cPickle as pickle        # For Python 2.x
 except ImportError:
     import pickle
-
-import numpy
 
 from .. import rioserrors
 # Import a pickler which can pickle functions, with their dependencies, as well

--- a/rios/rat.py
+++ b/rios/rat.py
@@ -62,7 +62,6 @@ def readColumnFromBand(gdalBand, colName):
 
     # get the size of the RAT  
     numCols = rat.GetColumnCount()
-    numRows = rat.GetRowCount()
   
     # if this is still None at the end
     # we didn't find the column

--- a/rios/readerinfo.py
+++ b/rios/readerinfo.py
@@ -249,7 +249,7 @@ class ReaderInfo(object):
         be what one wants. 
         
         """
-        (tl, br) = (self.blocktl, self.blockbr)
+        (tl, _) = (self.blocktl, self.blockbr)
         (nCols, nRows) = self.getBlockSize()
         nCols += 2*self.overlap
         nRows += 2*self.overlap

--- a/rios/riostests/testavgmpi.py
+++ b/rios/riostests/testavgmpi.py
@@ -27,8 +27,6 @@ Steals heavily from testavg
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from __future__ import print_function
 import os
-import sys
-import subprocess
 import numpy
 from osgeo import gdal
 from rios import applier

--- a/rios/riostests/testrat.py
+++ b/rios/riostests/testrat.py
@@ -23,12 +23,7 @@ import sys
 import numpy
 
 from rios import rat
-from rios import calcstats
-from rios import cuiprogress
 from rios.riostests import riostestutils
-
-from rios import ratapplier
-from rios import applier
 
 TESTNAME = 'TESTRAT'
 


### PR DESCRIPTION
Turns out that `cloudpickle.py` needs the `noqa` functionality to ignore certain lines that `flake8` has but `pyflakes` does not. Also, `pyflakes` appears to be unmaintained so I have changed the CI script to use `flake8` but ignoring all the codes that aren't `pyflakes` codes.

I think in time we maybe should fix up all the reasonable `flake8` warnings/errors but this is a good start for now.