### PR TITLE
Always put DontUseExceptions reset in the finally clause. Remove ungu…

### DIFF
--- a/rios/applier.py
+++ b/rios/applier.py
@@ -889,9 +889,7 @@ def opensAsRaster(filename):
     """
     Return True if filename opens as a GDAL raster, False otherwise
     """
-    usingExceptions = False
-    if hasattr(gdal, 'GetUseExceptions'):
-        usingExceptions = gdal.GetUseExceptions()
+    usingExceptions = gdal.GetUseExceptions()
     gdal.UseExceptions()
     try:
         ds = gdal.Open(filename)

--- a/rios/applier.py
+++ b/rios/applier.py
@@ -897,10 +897,11 @@ def opensAsRaster(filename):
         ds = gdal.Open(filename)
     except Exception:
         ds = None
+    finally:
+        if not usingExceptions:
+            gdal.DontUseExceptions()
+
     opensOK = (ds is not None)
-    
-    if not usingExceptions:
-        gdal.DontUseExceptions()
     return opensOK
 
 

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -27,10 +27,6 @@ from osgeo import gdal
 from . import cuiprogress
 from .rioserrors import ProcessCancelledError
 
-
-gdal.UseExceptions()
-
-
 # When calculating overviews (i.e. pyramid layers), default behaviour
 # is controlled by these
 dfltOverviewLvls = os.getenv('RIOS_DFLT_OVERVIEWLEVELS')
@@ -172,7 +168,7 @@ def addStatistics(ds, progress, ignore=None, approx_ok=False):
             tmpmeta["STATISTICS_EXCLUDEDVALUES"] = repr(ignore)  # doesn't seem to do anything
       
         # get GDAL to calculate statistics - force recalculation. Trap errors 
-        useExceptions = gdal.GetUseExceptions()
+        usingExceptions = gdal.GetUseExceptions()
         gdal.UseExceptions()
         try:
             if approx_ok and "LAYER_TYPE" in tmpmeta and tmpmeta["LAYER_TYPE"] == "thematic": 
@@ -187,8 +183,9 @@ def addStatistics(ds, progress, ignore=None, approx_ok=False):
                 stddevval = 0
             else:
                 raise e
-        if not useExceptions:
-            gdal.DontUseExceptions()
+        finally:
+            if not usingExceptions:
+                gdal.DontUseExceptions()
 
         percent = percent + percentstep
         progress.setProgress(percent)

--- a/rios/imagewriter.py
+++ b/rios/imagewriter.py
@@ -269,6 +269,10 @@ class ImageWriter(object):
                 ds = gdal.Open(str(filename))
             except RuntimeError:
                 ds = None
+            finally:
+                # Restore exception-use state
+                if not usingExceptions:
+                    gdal.DontUseExceptions()
 
             if ds is not None:
                 # It is apparently a valid GDAL file, so get the driver appropriate for it.
@@ -281,10 +285,6 @@ class ImageWriter(object):
                 # directly. 
                 os.remove(filename)
 
-            # Restore exception-use state
-            if not usingExceptions:
-                gdal.DontUseExceptions()
-            
     def getGDALDataset(self):
         """
         Returns the underlying GDAL dataset object

--- a/rios/rat.py
+++ b/rios/rat.py
@@ -240,8 +240,9 @@ def writeColumnToBand(gdalBand, colName, sequence, colType=None,
             gdalBand.SetDefaultRAT(attrTbl)
         except Exception:
             pass
-        if not usingExceptions:
-            gdal.DontUseExceptions()
+        finally:
+            if not usingExceptions:
+                gdal.DontUseExceptions()
 
 
 def writeColumn(imgFile, colName, sequence, colType=None, bandNumber=1, 


### PR DESCRIPTION
…arded use of UseExceptions in calcstats.py

I have checked calcstats.py, and other modules which import it, it there does not seem to be any further need for the unguarded call to gdal.UseExceptions. I expect to find I am wrong, but I can't see it. 
