### PR TITLE
add support for 64 bit ints

### DIFF
--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -126,7 +126,10 @@ def findOrCreateColumn(ratObj, usage, name, dtype):
 
 
 gdalLargeIntTypes = set([gdal.GDT_Int16, gdal.GDT_UInt16, gdal.GDT_Int32, gdal.GDT_UInt32])
-
+# hack for GDAL 3.5 and later which suppport 64 bit ints
+if hasattr(gdal, 'GDT_Int64'):
+    gdalLargeIntTypes.add(gdal.GDT_Int64)
+    gdalLargeIntTypes.add(gdal.GDT_UInt64)
 
 gdalFloatTypes = set([gdal.GDT_Float32, gdal.GDT_Float64])
 

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -359,4 +359,4 @@ def setNullValue(ds, nullValue):
     """
     for i in range(ds.RasterCount):
         band = ds.GetRasterBand(i + 1)
-        band.SetNoDataValue(float(nullValue))
+        band.SetNoDataValue(nullValue)

--- a/rios/imageio.py
+++ b/rios/imageio.py
@@ -73,7 +73,7 @@ dataTypeMapping = [
 ]
 
 # hack for GDAL 3.5 and later which suppport 64 bit ints
-if hasattr(gdal, 'GDT_Int64'):
+if hasattr(gdalconst, 'GDT_Int64'):
     dataTypeMapping.append((numpy.int64, gdalconst.GDT_Int64))
     dataTypeMapping.append((numpy.uint64, gdalconst.GDT_UInt64))
 

--- a/rios/imageio.py
+++ b/rios/imageio.py
@@ -74,8 +74,8 @@ dataTypeMapping = [
 
 # hack for GDAL 3.5 and later which suppport 64 bit ints
 if hasattr(gdal, 'GDT_Int64'):
-    dataTypeMapping.append((numpy.int64, gdal.GDT_Int64))
-    dataTypeMapping.append((numpy.uint64, gdal.GDT_UInt64))
+    dataTypeMapping.append((numpy.int64, gdalconst.GDT_Int64))
+    dataTypeMapping.append((numpy.uint64, gdalconst.GDT_UInt64))
 
 
 def GDALTypeToNumpyType(gdaltype):

--- a/rios/imageio.py
+++ b/rios/imageio.py
@@ -72,6 +72,11 @@ dataTypeMapping = [
     (numpy.float, gdalconst.GDT_Float64)
 ]
 
+# hack for GDAL 3.5 and later which suppport 64 bit ints
+if hasattr(gdal, 'GDT_Int64'):
+    dataTypeMapping.append((numpy.int64, gdal.GDT_Int64))
+    dataTypeMapping.append((numpy.uint64, gdal.GDT_UInt64))
+
 
 def GDALTypeToNumpyType(gdaltype):
     """


### PR DESCRIPTION
As added by GDAL 3.5.0.

Shouldn't break earlier versions

TODO: check error message you get when attempting to write an int64 image to a driver that doesn't support it.