### PR TITLE
Added VersionObj class, and use it to check GDAL for support of int64…

### DIFF
--- a/rios/__init__.py
+++ b/rios/__init__.py
@@ -24,3 +24,74 @@ classes, respectively.
 
 RIOS_VERSION = '1.4.12'
 __version__ = RIOS_VERSION
+
+
+# Used to fill in the rest of the comparison methods
+from functools import total_ordering
+
+@total_ordering
+class VersionObj(object):
+    """
+    Our own replacement for the old LooseVersion class,
+    since they deprecated that.
+
+    An instance of this class is initialized with a SemVer-style
+    version string, and instances can be compared for ordering in
+    a sensible way.
+
+    Yes, I know we could use setuptools.pkg_resources, or similar,
+    but I am sick of relying on other people's packages, when they
+    go and change them so easily. This will be constant. Sigh.....
+    """
+    def __init__(self, vstring):
+        """
+        vstring is a version string, something like "a.b.c"
+        where a, b & c are integers
+        """
+        self.vstring = vstring
+        self.components = None
+        if vstring is not None:
+            self.components = self.parse(vstring)
+
+    @staticmethod
+    def parse(vstring):
+        """
+        Return a tuple of version components.
+
+        Currently wants everything to be an int. Any trailing non-digits
+        will be ignored. This means that things like '2beta1' will be
+        treated the same as '2'.
+        """
+        fields = vstring.split('.')
+        components = []
+        for f in fields:
+            i = VersionObj.leadingDigits(f)
+            if len(i) > 0:
+                components.append(int(i))
+        return tuple(components)
+
+    @staticmethod
+    def leadingDigits(s):
+        """
+        Return the leading numeric digits of the given string,
+        up to anything non-digit.
+
+        Clever people would use a regular expression for this, but
+        I am not clever.
+        """
+        digits = []
+        i = 0
+        while i < len(s) and s[i].isdigit():
+            digits.append(s[i])
+            i += 1
+        return ''.join(digits)
+
+    def __repr__(self):
+        return "VersionObj('{}')".format(self.vstring)
+
+    # Methods to allow ordered comparisons
+    def __eq__(self, other):
+        return (self.components == other.components)
+
+    def __lt__(self, other):
+        return (self.components < other.components)

--- a/rios/__init__.py
+++ b/rios/__init__.py
@@ -21,13 +21,12 @@ imagewriter modules provide the ImageReader and ImageWriter
 classes, respectively. 
 
 """
+# Used to fill in the rest of the comparison methods
+from functools import total_ordering
 
 RIOS_VERSION = '1.4.12'
 __version__ = RIOS_VERSION
 
-
-# Used to fill in the rest of the comparison methods
-from functools import total_ordering
 
 @total_ordering
 class VersionObj(object):

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -56,7 +56,8 @@ def run():
         (gdal.GDT_Float64, 100),
         (gdal.GDT_Float64, 0.01)
     ]
-    # Include 64-bit int types, if supported
+    # Include 64-bit int types, if supported. Int64/UInt64 were not fully
+    # supported until 3.5.2 - see https://github.com/OSGeo/gdal/pull/6059
     if VersionObj(gdal.__version__) >= VersionObj('3.5.2'):
         dataTypesList.append((gdal.GDT_Int64, 30000))
         dataTypesList.append((gdal.GDT_UInt64, 30000))

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -38,7 +38,7 @@ def run():
     
     # We repeat the basic test for a number of different GDAL datatypes, with different
     # ranges of data. Each element of the following list is a tuple of
-    #    (gdalDataType, numpyDataType, scalefactor)
+    #    (gdalDataType, scalefactor)
     # for which the test is run. The original data being scaled is in 
     # the range 25-100 (after clobbering half the array as nulls, to ensure that
     # the nulls are enough to make a difference). 

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -21,7 +21,7 @@ import os
 import numpy
 from osgeo import gdal
 
-from rios import calcstats, cuiprogress, imageio
+from rios import calcstats, cuiprogress, imageio, VersionObj
 
 from . import riostestutils
 
@@ -57,7 +57,7 @@ def run():
         (gdal.GDT_Float64, 0.01)
     ]
     # Include 64-bit int types, if supported
-    if hasattr(gdal, 'GDT_UInt64'):
+    if VersionObj(gdal.__version__) >= VersionObj('3.5.2'):
         dataTypesList.append((gdal.GDT_Int64, 30000))
         dataTypesList.append((gdal.GDT_UInt64, 30000))
     


### PR DESCRIPTION
… raster types

The VersionObj class is a local replacement for the now-deprecated distutils.LooseVersion. We now need this to check GDAL for full support of int64 raster types, but we suspect it will come in handy into the future. 
