### PR TITLE
Use GDAL call for getting image data type name

### DIFF
--- a/rios/fileinfo.py
+++ b/rios/fileinfo.py
@@ -31,13 +31,6 @@ from osgeo import osr
 from . import rioserrors
 from . import rat
 
-# List of datatype names corresponding to GDAL datatype numbers. 
-# The index of this list corresponds to the gdal datatype number. Not sure if this 
-# is a bit obscure and cryptic.....
-GDALdatatypeNames = ['Unknown', 'UnsignedByte', 'UnsignedInt16', 'SignedInt16', 
-    'UnsignedInt32', 'SignedInt32', 'Float32', 'Float64', 'ComplexInt16', 'ComplexInt32', 
-    'ComplexFloat32', 'ComplexFloat64', 'SignedInt64', 'UnsignedInt64']
-
 
 class ImageInfo(object):
     """
@@ -109,7 +102,7 @@ class ImageInfo(object):
         
         # Pixel datatype, stored as a GDAL enum value. 
         self.dataType = ds.GetRasterBand(1).DataType
-        self.dataTypeName = GDALdatatypeNames[self.dataType]
+        self.dataTypeName = gdal.GetDataTypeName(self.dataType)
         
         del ds
 

--- a/rios/fileinfo.py
+++ b/rios/fileinfo.py
@@ -36,7 +36,7 @@ from . import rat
 # is a bit obscure and cryptic.....
 GDALdatatypeNames = ['Unknown', 'UnsignedByte', 'UnsignedInt16', 'SignedInt16', 
     'UnsignedInt32', 'SignedInt32', 'Float32', 'Float64', 'ComplexInt16', 'ComplexInt32', 
-    'ComplexFloat32', 'ComplexFloat64']
+    'ComplexFloat32', 'ComplexFloat64', 'SignedInt64', 'UnsignedInt64']
 
 
 class ImageInfo(object):


### PR DESCRIPTION
Something we missed before.

There is actually a GDAL function `gdal.GetDataTypeName` that maybe we should be using instead. However this returns an abbreviated form ('UInt16' rather than 'UnsignedInt16') so this change may break existing code. 

@tonykgill suggested creating a function can be used to return the datatype string - (if there isn't one already? Have an optional argument that specifies which type of name your want returned - a rios data type name, or a gdal data type name. This should default to RIOS, so as not to introduce breaking behaviour.

If a rios type name is requested, then use a dictionary to define the mappings from gdal data type to rios data type name. If a data type is missing from the dictionary, then fall back to the gdal.GetDataTypeName.

If a gdal type name is requested, use gdal.GetDataTypeName.

What do you think?