### PR TITLE
Use gdal.ApplyGeoTransform in pix2wld and wld2pix.

### DIFF
--- a/rios/imageio.py
+++ b/rios/imageio.py
@@ -23,6 +23,7 @@ writing modules
 
 import numpy
 from osgeo import gdalconst
+from osgeo import gdal
 
 from . import rioserrors
 
@@ -40,21 +41,14 @@ class Coord:
 
 def wld2pix(transform, geox, geoy):
     """converts a set of map coords to pixel coords"""
-    x = (transform[0] * transform[5] - 
-        transform[2] * transform[3] + transform[2] * geoy - 
-        transform[5] * geox) / (transform[2] * transform[4] - transform[1] * transform[5])
-
-    y = (transform[1] * transform[3] - transform[0] * transform[4] -
-        transform[1] * geoy + transform[4] * geox) / (transform[2] * transform[4] - transform[1] * transform[5])
-
+    inv_transform = gdal.InvGeoTransform(transform)
+    x, y = gdal.ApplyGeoTransform(inv_transform, geox, geoy)
     return Coord(x, y)
 
 
 def pix2wld(transform, x, y):
     """converts a set of pixels coords to map coords"""
-    geox = transform[0] + transform[1] * x + transform[2] * y
-    geoy = transform[3] + transform[4] * x + transform[5] * y
-
+    geox, geoy = gdal.ApplyGeoTransform(transform, x, y)
     return Coord(geox, geoy)
 
 


### PR DESCRIPTION
@neilflood 

@gillins discussed the possibility of using gdal's ApplyGeoTransform function to change how imageio.wld2pix and image.pix2wld are implemented.

This P.R. implements the change.

If I managed to run the tests correctly, then it appears that the changes pass the tests. (I placed print statements - not shown - in the wld2pix and pix2wld functions that confirmed the test called them several times.)

```bash
root@55c82f37899c:~/rios# python3
Python 3.10.4 (main, Jun 29 2022, 12:14:53) [GCC 11.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from rios.riostests import testcoords
>>> testcoords.run()

####################
Starting test: TESTCOORDS
TESTCOORDS: Passed
True
```