### PR TITLE
Cope with numpy-1.24 type symbol deprecations

### DIFF
--- a/rios/imageio.py
+++ b/rios/imageio.py
@@ -71,6 +71,12 @@ if hasattr(gdalconst, 'GDT_Int64'):
     dataTypeMapping.append((numpy.int64, gdalconst.GDT_Int64))
     dataTypeMapping.append((numpy.uint64, gdalconst.GDT_UInt64))
 
+# With GDAL 3.7, there is a plan to introduce GDT_Int8, so try to cope with it.
+# Hopefully OK, because we did not previously have anything to cope with arrays
+# of type numpy.int8.
+if hasattr(gdalconst, 'GDT_Int8'):
+    dataTypeMapping.append((numpy.int8, gdalconst.GDT_Int8))
+
 
 def GDALTypeToNumpyType(gdaltype):
     """

--- a/rios/imageio.py
+++ b/rios/imageio.py
@@ -57,13 +57,13 @@ def pix2wld(transform, x, y):
 # is the one chosen. 
 dataTypeMapping = [
     (numpy.uint8, gdalconst.GDT_Byte),
-    (numpy.bool, gdalconst.GDT_Byte),
+    (bool, gdalconst.GDT_Byte),
     (numpy.int16, gdalconst.GDT_Int16),
     (numpy.uint16, gdalconst.GDT_UInt16),
     (numpy.int32, gdalconst.GDT_Int32),
     (numpy.uint32, gdalconst.GDT_UInt32),
-    (numpy.single, gdalconst.GDT_Float32),
-    (numpy.float, gdalconst.GDT_Float64)
+    (numpy.float32, gdalconst.GDT_Float32),
+    (numpy.float64, gdalconst.GDT_Float64)
 ]
 
 # hack for GDAL 3.5 and later which suppport 64 bit ints

--- a/rios/rat.py
+++ b/rios/rat.py
@@ -321,7 +321,7 @@ def getColorTable(imgFile, bandNumber=1):
 
     count = colorTable.GetCount()
     # count could be any size so we have to go with int
-    colorArray = numpy.zeros((count, 5), dtype=numpy.int)
+    colorArray = numpy.zeros((count, 5), dtype=int)
     for index in range(count):
         colorEntry = colorTable.GetColorEntry(index)
         arrayEntry = [index] + list(colorEntry)


### PR DESCRIPTION
This now passes standard tests under numpy-1.24.0. 