### PR TITLE
Fix histogram for larger types

### DIFF
--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -261,8 +261,9 @@ def addStatistics(ds, progress, ignore=None, approx_ok=False):
         userdata.nbands = ds.RasterCount * 2
         userdata.curroffset = percent
       
-        # get histogram and force GDAL to recalculate it
-        hist = band.GetHistogram(histCalcMin, histCalcMax, histnbins, False, 
+        # Get histogram and force GDAL to recalculate it. Note that we use include_out_of_range=True,
+        # which is safe because we have calculated the histCalcMin/Max from the data. 
+        hist = band.GetHistogram(histCalcMin, histCalcMax, histnbins, True,
                         approx_ok, progressFunc, userdata)
         
         # Check if GDAL's histogram code overflowed. This is not a fool-proof test,


### PR DESCRIPTION
It appears that for some cases, the histogram was slightly incorrect. 

In the cases of athematic integer raster with datatype larger than 8-bit, the histogram would be missing the count of the largest pixel value (i.e. the very last bin would be missing). This was happening because GDAL's Band.GetHistogram() function does comparisons against the given histogramMax with `<`. So, unless this is strictly larger than all the pixel values, the largest one would count as out of range, and so be ignored. 

The fix for this is to use `include_out_of_range=True` in the call to band.GetHistogram. This way, all non-null pixels will be counted. 

Note that this is only safe because we have calculated the histCalcMin & histCalcMax to be the extremes of the data. If, for some reason, there were pixel values genuinely outside this range, then the end bins would show counts larger than expected. However, since we have (hopefully) calculated the range correctly, this should not cause any troubles. 

This error was allowed to persist because we did not have any test on the histogram values. I have now added a simple test, just of the total count. With the call to GetHistogram() as it was before, this test shows a failure, but with the fix described above it now passes the new test. I might wish for a stronger test of the histogram, but it turns out that doing something which works for all datatypes/file formats/data ranges is harder than it sounds, so this will do for now. 

Ping @gillins. I would welcome your thoughts. 