### PR TITLE
Remove RAT writing code from ImageWriter

### DIFF
--- a/rios/imagewriter.py
+++ b/rios/imagewriter.py
@@ -306,15 +306,6 @@ class ImageWriter(object):
             band = self.ds.GetRasterBand(i)
             band.SetMetadataItem('LAYER_TYPE', 'thematic')
                         
-    def setColorTable(self, colortable, band=1):
-        """
-        Sets the output color table. Pass a list
-        of sequences of colors, or a 2d array, as per the
-        docstring for rat.setColorTable(). 
-        """
-        colorTableArray = numpy.array(colortable)
-        rat.setColorTable(self.ds, colorTableArray, layernum=band)
-        
     def setLayerNames(self, names):
         """
         Sets the output layer names. Pass a list
@@ -373,13 +364,6 @@ class ImageWriter(object):
                 
             bh.WriteArray(outblock, xcoord, ycoord)
 
-    def setAttributeColumn(self, colName, sequence, colType=None, bandNumber=1):
-        """
-        Puts the sequence into colName in the output file. See rios.rat.writeColumn
-        for more information. You probably also want to call setThematic().
-        """
-        rat.writeColumn(self.ds, colName, sequence, colType, bandNumber)
-    
     def reset(self):
         """
         Resets the location pointer so that the next

--- a/rios/rat.py
+++ b/rios/rat.py
@@ -4,7 +4,7 @@ This module contains routines for reading and writing Raster
 Attribute Tables (RATs). These are designed to be able to 
 be called from outside of RIOS.
 
-Within RIOS, these are called from the :class:`rios.readerinfo.ReaderInfo` 
+Within RIOS, these are called from the :class:`rios.imagewriter.ImageWriter 
 and :class:`rios.fileinfo.ImageInfo` classes.
 
 **Note:** It is recommended that the newer :mod:`rios.ratapplier` module be used instead of this

--- a/rios/rat.py
+++ b/rios/rat.py
@@ -5,7 +5,7 @@ Attribute Tables (RATs). These are designed to be able to
 be called from outside of RIOS.
 
 Within RIOS, these are called from the :class:`rios.readerinfo.ReaderInfo` 
-and :class:`rios.imagewriter.ImageWriter` classes.
+and :class:`rios.fileinfo.ImageInfo` classes.
 
 **Note:** It is recommended that the newer :mod:`rios.ratapplier` module be used instead of this
 interface for large tables where possible.


### PR DESCRIPTION
Got missed in #57. Also fixed a docstring. 

I think we should leave the auto colour table stuff in for now?