### PR TITLE
add entry points for command line scripts without extensions

### DIFF
--- a/bin/rioscalcstats.py
+++ b/bin/rioscalcstats.py
@@ -5,5 +5,7 @@ Use rios.calcstats to calculate statistics for the given image(s).
 """
 
 from rios.cmdline import rioscalcstats
+import warnings
+warnings.warn("Future versions of RIOS may remove the .py extension from this script name", DeprecationWarning)
 
 rioscalcstats.main()

--- a/bin/riosprintstats.py
+++ b/bin/riosprintstats.py
@@ -5,5 +5,7 @@ Use rios.fileinfo to print the statistics for the given image(s).
 """
 
 from rios.cmdline import riosprintstats
+import warnings
+warnings.warn("Future versions of RIOS may remove the .py extension from this script name", DeprecationWarning)
 
 riosprintstats.main()

--- a/bin/testrios.py
+++ b/bin/testrios.py
@@ -28,6 +28,8 @@ if __name__ == '__main__':
     # the __name__ == '__main__' is required under Windows
     # so they multiprocessing module works.
     from rios.riostests import riostestutils
+    import warnings
+    warnings.warn("Future versions of RIOS may remove the .py extension from this script name", DeprecationWarning)
 
     if riostestutils.testAll() > 0:
         # return error code

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,12 @@ setup(name='rios',
       author='Sam Gillingham',
       author_email='gillingham.sam@gmail.com',
       scripts=scripts_list,
+      entry_points={
+        'console_scripts': [
+            'testrios = rios.riostests.riostestutils:testAll',
+            'rioscalcstats = rios.cmdline.rioscalcstats:main',
+            'riosprintstats = rios.cmdline.riosprintstats:main'
+        ]},
       packages=['rios', 'rios/parallel', 'rios/parallel/aws',
                         'rios/riostests', 'rios/cmdline'],
       license='LICENSE.txt', 


### PR DESCRIPTION
And print a warning when using the versions with extensions.

Having extensions causes all sorts of headaches on Windows. Plus it seems more 'standard' across the board not to have extensions for command line scripts.

The `subproc` scripts don't need to be changed as they are called internally and not by the user and the current mechanism for running them won't benefit from the creation of entry points.