### PR TITLE
suppress GDAL testsuite warning by calling gdal.UseExceptions()

### DIFF
--- a/rios/riostests/riostestutils.py
+++ b/rios/riostests/riostestutils.py
@@ -32,6 +32,8 @@ from osgeo import ogr
 
 from rios import rioserrors
 
+gdal.UseExceptions()
+
 DEFAULT_ROWS = 500
 DEFAULT_COLS = 500
 DEFAULT_PIXSIZE = 10

--- a/setup.py
+++ b/setup.py
@@ -43,11 +43,11 @@ setup(name='rios',
       author_email='gillingham.sam@gmail.com',
       scripts=scripts_list,
       entry_points={
-        'console_scripts': [
-            'testrios = rios.riostests.riostestutils:testAll',
-            'rioscalcstats = rios.cmdline.rioscalcstats:main',
-            'riosprintstats = rios.cmdline.riosprintstats:main'
-        ]},
+          'console_scripts': [
+              'testrios = rios.riostests.riostestutils:testAll',
+              'rioscalcstats = rios.cmdline.rioscalcstats:main',
+              'riosprintstats = rios.cmdline.riosprintstats:main'
+          ]},
       packages=['rios', 'rios/parallel', 'rios/parallel/aws',
                         'rios/riostests', 'rios/cmdline'],
       license='LICENSE.txt', 


### PR DESCRIPTION
Also tidy formatting of `setup.py`. 

Warnings come about in recent GDAL versions in preparation for GDAL 4.0.

I found just calling `gdal.UseExceptions()` in one place seemed to quieten the warnings for all the `test*.py` files, although the problem may still lurk if you specifically imported and ran one test. I'm not sure this is a common scenario.