### PR TITLE
add missing FlushCache call to addPyramid()

### DIFF
--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -69,6 +69,9 @@ def addPyramid(ds, progress,
     """
     progress.setLabelText("Computing Pyramid Layers...")
     progress.setProgress(0)
+    
+    # ensure everything is written to disc first
+    ds.FlushCache()
 
     # first we work out how many overviews to build based on the size
     if ds.RasterXSize < ds.RasterYSize:


### PR DESCRIPTION
Before https://github.com/ubarsc/rios/commit/3bca2a5f02d2906f7ce02cb5158e94e1d76937c9 we used to calculate stats before pyramid layers. `addStatistics` had a ds.FlushCache() call at the beginning so we knew all the blocks were written before reading the file to work out the stats and make the pyramid layers. In this commit the order was changed so that the pyramid layers were calculated first so that they would be available for approximating statistics. However we never moved the ds.FlushCache call. It seems in certain situations with large files (only seen on Windows, but could in theory happen elsewhere) not all the blocks are written out before the pyramid layers are calculating resulting in a GDAL error. 

This PR adds a ds.FlushCache to `addPyramid` also so all blocks are written whichever order the functions are called in.

Problem reported by and fix confirmed by @t-hackwood.