### PR TITLE
Various improvements to AWS Batch support

### DIFF
--- a/doc/source/environmentvars.rst
+++ b/doc/source/environmentvars.rst
@@ -74,7 +74,7 @@ RIOS honours the following environment variables which can be used to override d
 |RIOS_BATCH_STACK				| The CloudFormation stack name to use  | RIOS			 | Not in controls		 |
 |								| for AWS Batch jobs					|				 |						 | 
 +-------------------------------+---------------------------------------+----------------+-----------------------+
-|RIOS_BATCH_REGION				| The AWS Region to look for the 		| ap-southeast-2 | Not in controls		 |
+|RIOS_AWSBATCH_REGION			| The AWS Region to look for the 		| ap-southeast-2 | Not in controls		 |
 |								| CloudFormation stack specified by		| 				 |						 |
 |								| DFLT_BATCH_STACK.						|				 |						 |
 +-------------------------------+---------------------------------------+----------------+-----------------------+

--- a/doc/source/environmentvars.rst
+++ b/doc/source/environmentvars.rst
@@ -71,7 +71,7 @@ RIOS honours the following environment variables which can be used to override d
 |                               | will be used instead. Added in RIOS   |                |                       |
 |                               | 1.4.5.                                |                |                       |
 +-------------------------------+---------------------------------------+----------------+-----------------------+
-|RIOS_BATCH_STACK				| The CloudFormation stack name to use  | RIOS			 | Not in controls		 |
+|RIOS_AWSBATCH_STACK			| The CloudFormation stack name to use  | RIOS			 | Not in controls		 |
 |								| for AWS Batch jobs					|				 |						 | 
 +-------------------------------+---------------------------------------+----------------+-----------------------+
 |RIOS_AWSBATCH_REGION			| The AWS Region to look for the 		| ap-southeast-2 | Not in controls		 |

--- a/rios/parallel/aws/batch.py
+++ b/rios/parallel/aws/batch.py
@@ -23,7 +23,8 @@ to create a separate VPC with all the infrastructure required. It is recommended
 to use the script `templates/createbatch.py` for the creation or modification (via the ``--modify``
 command line option) of this CloudFormation stack. There are also options for
 overriding some of the input parameters - see the output of `createbatch.py --help`
-for more information.
+for more information. NB: when running in a region that is NOT ap-southeast-2 you will
+need to update the availability zones (--az command line option).
 
 When you have completed processing you can run ``templates/deletebatch.py`` to delete
 all resources so you aren't paying for it. Note that you specify the region and stack

--- a/rios/parallel/aws/batch.py
+++ b/rios/parallel/aws/batch.py
@@ -28,7 +28,7 @@ need to update the availability zones (--az command line option).
 
 When you have completed processing you can run ``templates/deletebatch.py`` to delete
 all resources so you aren't paying for it. Note that you specify the region and stack
-name for this script via the RIOS_AWSBATCH_REGION and RIOS_BATCH_STACK environment variables.
+name for this script via the RIOS_AWSBATCH_REGION and RIOS_AWSBATCH_STACK environment variables.
 
 Note that both ``createbatch.py`` and ``deletebatch.py`` have a ``--wait`` option that causes the
 script to keep running until creation/deletion is complete. 
@@ -95,7 +95,7 @@ Don't forget to pass in your ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``
 container when it runs (these variables are automatically set if running as a AWS Batch job but you'll
 need to set them otherwise).
 
-Also a good idea to pass in your RIOS_AWSBATCH_REGION and RIOS_BATCH_STACK environment variables if the
+Also a good idea to pass in your RIOS_AWSBATCH_REGION and RIOS_AWSBATCH_STACK environment variables if the
 defaults have been overridden so that RIOS can find the CloudFormation stack.
 
 To also run you "main" Dockerfile as a batch job, push to the "RIOSecrMain" repository created by 
@@ -112,7 +112,7 @@ import cloudpickle
 from .. import jobmanager
 
 
-STACK_NAME = os.getenv('RIOS_BATCH_STACK', default='RIOS')
+STACK_NAME = os.getenv('RIOS_AWSBATCH_STACK', default='RIOS')
 REGION = os.getenv('RIOS_AWSBATCH_REGION', default='ap-southeast-2')
 
 
@@ -124,7 +124,7 @@ def getStackOutputs():
     """
     Helper function to query the CloudFormation stack for outputs.
     
-    Uses the RIOS_BATCH_STACK and RIOS_AWSBATCH_REGION env vars to 
+    Uses the RIOS_AWSBATCH_STACK and RIOS_AWSBATCH_REGION env vars to 
     determine which stack and region to query.
     """
     client = boto3.client('cloudformation', region_name=REGION)

--- a/rios/parallel/aws/batch.py
+++ b/rios/parallel/aws/batch.py
@@ -28,7 +28,7 @@ need to update the availability zones (--az command line option).
 
 When you have completed processing you can run ``templates/deletebatch.py`` to delete
 all resources so you aren't paying for it. Note that you specify the region and stack
-name for this script via the RIOS_BATCH_REGION and RIOS_BATCH_STACK environment variables.
+name for this script via the RIOS_AWSBATCH_REGION and RIOS_BATCH_STACK environment variables.
 
 Note that both ``createbatch.py`` and ``deletebatch.py`` have a ``--wait`` option that causes the
 script to keep running until creation/deletion is complete. 
@@ -40,26 +40,26 @@ AWS Batch requires you to provide a Docker image with the required software inst
 A `Dockerfile` is provided for this, but it it recommended that you use the `Makefile`
 to build the image as this handles the details of pulling the names out of the CloudFormation
 stack and creating a tar file of RIOS for copying into the Docker image. To build and push to 
-ECR simply run (being careful to set RIOS_BATCH_REGION to the correct AWS region)::
+ECR simply run (being careful to set RIOS_AWSBATCH_REGION to the correct AWS region)::
 
-    RIOS_BATCH_REGION=ap-southeast-2 make
+    RIOS_AWSBATCH_REGION=ap-southeast-2 make
 
 By default this image includes GDAL, boto3 and RIOS. 
 
 Normally your script will need extra packages to run. You can specify the names of Ubuntu packages
 to also install with the environment variable `EXTRA_PACKAGES` like this::
 
-    EXTRA_PACKAGES="python3-sklearn python3-skimage" RIOS_BATCH_REGION=ap-southeast-2 make
+    EXTRA_PACKAGES="python3-sklearn python3-skimage" RIOS_AWSBATCH_REGION=ap-southeast-2 make
 
 
 You can also use the `PIP_PACKAGES` environment variable to set the name of any pip packages like this::
 
-    PIP_PACKAGES="pydantic python-dateutil" RIOS_BATCH_REGION=ap-southeast-2 make
+    PIP_PACKAGES="pydantic python-dateutil" RIOS_AWSBATCH_REGION=ap-southeast-2 make
 
 You can also specify both if needed::
 
     EXTRA_PACKAGES="python3-sklearn python3-skimage" PIP_PACKAGES="pydantic python-dateutil" \
-        RIOS_BATCH_REGION=ap-southeast-2 make
+        RIOS_AWSBATCH_REGION=ap-southeast-2 make
 
 Setting up your main script
 ---------------------------
@@ -95,7 +95,7 @@ Don't forget to pass in your ``AWS_ACCESS_KEY_ID`` and ``AWS_SECRET_ACCESS_KEY``
 container when it runs (these variables are automatically set if running as a AWS Batch job but you'll
 need to set them otherwise).
 
-Also a good idea to pass in your RIOS_BATCH_REGION and RIOS_BATCH_STACK environment variables if the
+Also a good idea to pass in your RIOS_AWSBATCH_REGION and RIOS_BATCH_STACK environment variables if the
 defaults have been overridden so that RIOS can find the CloudFormation stack.
 
 To also run you "main" Dockerfile as a batch job, push to the "RIOSecrMain" repository created by 
@@ -113,7 +113,7 @@ from .. import jobmanager
 
 
 STACK_NAME = os.getenv('RIOS_BATCH_STACK', default='RIOS')
-REGION = os.getenv('RIOS_BATCH_REGION', default='ap-southeast-2')
+REGION = os.getenv('RIOS_AWSBATCH_REGION', default='ap-southeast-2')
 
 
 class AWSBatchException(Exception):
@@ -124,7 +124,7 @@ def getStackOutputs():
     """
     Helper function to query the CloudFormation stack for outputs.
     
-    Uses the RIOS_BATCH_STACK and RIOS_BATCH_REGION env vars to 
+    Uses the RIOS_BATCH_STACK and RIOS_AWSBATCH_REGION env vars to 
     determine which stack and region to query.
     """
     client = boto3.client('cloudformation', region_name=REGION)

--- a/rios/parallel/aws/batch.py
+++ b/rios/parallel/aws/batch.py
@@ -39,25 +39,26 @@ AWS Batch requires you to provide a Docker image with the required software inst
 A `Dockerfile` is provided for this, but it it recommended that you use the `Makefile`
 to build the image as this handles the details of pulling the names out of the CloudFormation
 stack and creating a tar file of RIOS for copying into the Docker image. To build and push to 
-ECR simply run::
+ECR simply run (being careful to set RIOS_BATCH_REGION to the correct AWS region)::
 
-    make
+    RIOS_BATCH_REGION=ap-southeast-2 make
 
 By default this image includes GDAL, boto3 and RIOS. 
 
 Normally your script will need extra packages to run. You can specify the names of Ubuntu packages
 to also install with the environment variable `EXTRA_PACKAGES` like this::
 
-    EXTRA_PACKAGES="python3-sklearn python3-skimage" make
+    EXTRA_PACKAGES="python3-sklearn python3-skimage" RIOS_BATCH_REGION=ap-southeast-2 make
 
 
 You can also use the `PIP_PACKAGES` environment variable to set the name of any pip packages like this::
 
-    PIP_PACKAGES="pydantic python-dateutil" make
+    PIP_PACKAGES="pydantic python-dateutil" RIOS_BATCH_REGION=ap-southeast-2 make
 
 You can also specify both if needed::
 
-    EXTRA_PACKAGES="python3-sklearn python3-skimage" PIP_PACKAGES="pydantic python-dateutil" make
+    EXTRA_PACKAGES="python3-sklearn python3-skimage" PIP_PACKAGES="pydantic python-dateutil" \
+        RIOS_BATCH_REGION=ap-southeast-2 make
 
 Setting up your main script
 ---------------------------
@@ -96,8 +97,8 @@ need to set them otherwise).
 Also a good idea to pass in your RIOS_BATCH_REGION and RIOS_BATCH_STACK environment variables if the
 defaults have been overridden so that RIOS can find the CloudFormation stack.
 
-Needless to say the account that this "main" script run as should have sufficient permissions on the resources 
-created by CloudFormation. 
+To also run you "main" Dockerfile as a batch job, push to the "RIOSecrMain" repository created by 
+``templates/batch.yaml``. You can then submit jobs to the RIOSJobQueue using the RIOSJobDefinitionMain.
  
 """
 

--- a/rios/parallel/aws/templates/Dockerfile
+++ b/rios/parallel/aws/templates/Dockerfile
@@ -7,11 +7,13 @@ ARG EXTRA_PACKAGES
 ARG PIP_PACKAGES
 ARG RIOS_VER
 ARG AWS_REGION=ap-southeast-2
+ENV AWS_REGION=$AWS_REGION
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
 # use local mirror
+RUN sed -i 's/http:\/\/ports./http:\/\/${AWS_REGION}.ec2.ports./g' /etc/apt/sources.list
 RUN sed -i 's/http:\/\/archive./http:\/\/${AWS_REGION}.ec2.archive./g' /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get upgrade -y

--- a/rios/parallel/aws/templates/Dockerfile
+++ b/rios/parallel/aws/templates/Dockerfile
@@ -7,14 +7,14 @@ ARG EXTRA_PACKAGES
 ARG PIP_PACKAGES
 ARG RIOS_VER
 ARG AWS_REGION=ap-southeast-2
-ENV AWS_REGION=$AWS_REGION
+ENV AWS_REGION_ENV=$AWS_REGION
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
 # use local mirror
-RUN sed -i 's/http:\/\/ports./http:\/\/${AWS_REGION}.ec2.ports./g' /etc/apt/sources.list
-RUN sed -i 's/http:\/\/archive./http:\/\/${AWS_REGION}.ec2.archive./g' /etc/apt/sources.list
+RUN sed -i "s/http:\/\/ports./http:\/\/${AWS_REGION_ENV}.ec2.ports./g" /etc/apt/sources.list
+RUN sed -i "s/http:\/\/archive./http:\/\/${AWS_REGION_ENV}.ec2.archive./g" /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get upgrade -y
 

--- a/rios/parallel/aws/templates/Dockerfile
+++ b/rios/parallel/aws/templates/Dockerfile
@@ -6,19 +6,19 @@ FROM ubuntu:22.04
 ARG EXTRA_PACKAGES
 ARG PIP_PACKAGES
 ARG RIOS_VER
+ARG AWS_REGION=ap-southeast-2
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV PYTHONUNBUFFERED=1
 
-# Use Aussie mirrors (TODO: a way of setting theses?)
-RUN sed -i 's/http:\/\/archive./http:\/\/ap-southeast-2.ec2.archive./g' /etc/apt/sources.list
+# use local mirror
+RUN sed -i 's/http:\/\/archive./http:\/\/${AWS_REGION}.ec2.archive./g' /etc/apt/sources.list
 RUN apt-get update
 RUN apt-get upgrade -y
 
 # install our prereqs, plus anything else the user has asked for
 RUN apt-get install -y python3-gdal python3-boto3 python3-cloudpickle python3-pip $EXTRA_PACKAGES
 
-# Copy the source archive created by the Makefile
 COPY rios-$RIOS_VER.tar.gz /tmp
 # install RIOS
 RUN cd /tmp && tar xf rios-$RIOS_VER.tar.gz \

--- a/rios/parallel/aws/templates/Makefile
+++ b/rios/parallel/aws/templates/Makefile
@@ -25,6 +25,6 @@ dist:
 # Login to ECR, build package and push to ECR
 all: dist
 	aws ecr get-login-password --region ${RIOS_BATCH_REGION} | docker login --username AWS --password-stdin $(ECR_URL)
-	docker build AWS_REGION=${RIOS_BATCH_REGION} --build-arg EXTRA_PACKAGES=${EXTRA_PACKAGES} --build-arg=PIP_PACKAGES=${PIP_PACKAGES} --build-arg RIOS_VER=$(RIOS_VER) -t rios .
+	docker build --build-arg AWS_REGION=${RIOS_BATCH_REGION} --build-arg EXTRA_PACKAGES=${EXTRA_PACKAGES} --build-arg=PIP_PACKAGES=${PIP_PACKAGES} --build-arg RIOS_VER=$(RIOS_VER) -t rios .
 	docker tag rios $(REPO)
 	docker push $(REPO)

--- a/rios/parallel/aws/templates/Makefile
+++ b/rios/parallel/aws/templates/Makefile
@@ -1,13 +1,13 @@
 # A make file to create and push a docker image with RIOS and any other required packages
 # to ECR.
-# set the RIOS_BATCH_REGION environment variable to the name of the AWS region you wish to use
+# set the RIOS_AWSBATCH_REGION environment variable to the name of the AWS region you wish to use
 # To request other packages be installed into this docker either or both of:
 # EXTRA_PACKAGES environment variable (for Ubuntu pakackes)
 # PIP_PACKAGES environment variable (for pip pakackes)
 # These accept a space seperated list of package names
 
-ifndef RIOS_BATCH_REGION
-$(error RIOS_BATCH_REGION is not set)
+ifndef RIOS_AWSBATCH_REGION
+$(error RIOS_AWSBATCH_REGION is not set)
 endif
 
 ECR_URL := $(shell ./print_ecr_path.py --base)
@@ -24,7 +24,7 @@ dist:
 
 # Login to ECR, build package and push to ECR
 all: dist
-	aws ecr get-login-password --region ${RIOS_BATCH_REGION} | docker login --username AWS --password-stdin $(ECR_URL)
-	docker build --build-arg AWS_REGION=${RIOS_BATCH_REGION} --build-arg EXTRA_PACKAGES=${EXTRA_PACKAGES} --build-arg=PIP_PACKAGES=${PIP_PACKAGES} --build-arg RIOS_VER=$(RIOS_VER) -t rios .
+	aws ecr get-login-password --region ${RIOS_AWSBATCH_REGION} | docker login --username AWS --password-stdin $(ECR_URL)
+	docker build --build-arg AWS_REGION=${RIOS_AWSBATCH_REGION} --build-arg EXTRA_PACKAGES=${EXTRA_PACKAGES} --build-arg=PIP_PACKAGES=${PIP_PACKAGES} --build-arg RIOS_VER=$(RIOS_VER) -t rios .
 	docker tag rios $(REPO)
 	docker push $(REPO)

--- a/rios/parallel/aws/templates/Makefile
+++ b/rios/parallel/aws/templates/Makefile
@@ -1,9 +1,14 @@
 # A make file to create and push a docker image with RIOS and any other required packages
 # to ECR.
+# set the RIOS_BATCH_REGION environment variable to the name of the AWS region you wish to use
 # To request other packages be installed into this docker either or both of:
 # EXTRA_PACKAGES environment variable (for Ubuntu pakackes)
 # PIP_PACKAGES environment variable (for pip pakackes)
 # These accept a space seperated list of package names
+
+ifndef RIOS_BATCH_REGION
+$(error RIOS_BATCH_REGION is not set)
+endif
 
 ECR_URL := $(shell ./print_ecr_path.py --base)
 REPO := $(shell ./print_ecr_path.py):latest
@@ -19,7 +24,7 @@ dist:
 
 # Login to ECR, build package and push to ECR
 all: dist
-	aws ecr get-login-password --region ap-southeast-2 | docker login --username AWS --password-stdin $(ECR_URL)
-	docker build --build-arg EXTRA_PACKAGES=${EXTRA_PACKAGES} --build-arg=PIP_PACKAGES=${PIP_PACKAGES} --build-arg RIOS_VER=$(RIOS_VER) -t rios .
+	aws ecr get-login-password --region ${RIOS_BATCH_REGION} | docker login --username AWS --password-stdin $(ECR_URL)
+	docker build AWS_REGION=${RIOS_BATCH_REGION} --build-arg EXTRA_PACKAGES=${EXTRA_PACKAGES} --build-arg=PIP_PACKAGES=${PIP_PACKAGES} --build-arg RIOS_VER=$(RIOS_VER) -t rios .
 	docker tag rios $(REPO)
 	docker push $(REPO)

--- a/rios/parallel/aws/templates/batch.yaml
+++ b/rios/parallel/aws/templates/batch.yaml
@@ -149,7 +149,7 @@ Resources:
   BatchRepositoryMain:
     Type: AWS::ECR::Repository
     Properties:
-      RepositoryName: !Join ['', [!Ref ServiceName, "ecrMain"]]
+      RepositoryName: !Join ['', [!Ref ServiceName, "ecrmain"]]
       LifecyclePolicy:
         LifecyclePolicyText: |
           {
@@ -244,8 +244,10 @@ Resources:
           Action: 
             - 'batch:SubmitJob'
           Resource:
-            - !GetAtt BatchProcessingJobDefinition.Arn
-            - !GetAtt BatchProcessingJobQueue.Arn
+            # Sorry can't nail down to particular queue and defn
+            # as this creates a circular dependency
+            - !Sub 'arn:aws:batch:${AWS::Region}:${AWS::AccountId}:job-queue/*'
+            - !Sub 'arn:aws:batch:${AWS::Region}:${AWS::AccountId}:job-definition/*'
       
   # Needed by AWS Batch.
   BatchServiceRole:

--- a/rios/parallel/aws/templates/batch.yaml
+++ b/rios/parallel/aws/templates/batch.yaml
@@ -313,13 +313,6 @@ Resources:
         Image: !Join ['', [!GetAtt BatchRepositoryMain.RepositoryUri, ":latest"]]
         Vcpus: !Ref VCPUS
         Memory: !Ref MaxMemory
-        Environment:
-          - Name: "RIOSBucket"
-            Value: !Ref BatchBucket
-          - Name: "RIOSInQueue"
-            Value: !Ref BatchInQueue
-          - Name: "RIOSOutQueue"
-            Value: !Ref BatchOutQueue
   # Our queue
   BatchProcessingJobQueue:
     Type: AWS::Batch::JobQueue
@@ -378,6 +371,8 @@ Outputs:
     Value: !Join ['', [!Ref ServiceName, "JobDefinitionMain"]]
   BatchECR:
     Value: !GetAtt BatchRepository.RepositoryUri
+  BatchECRMain:
+    Value: !GetAtt BatchRepositoryMain.RepositoryUri
   BatchInQueue:
     Value:
       Ref: BatchInQueue

--- a/rios/parallel/aws/templates/batch.yaml
+++ b/rios/parallel/aws/templates/batch.yaml
@@ -284,6 +284,9 @@ Resources:
       - arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role
       - arn:aws:iam::aws:policy/CloudWatchFullAccess
       - arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
+      # giving s3 readonly everywhere along with more specific policy (AccessS3ManagedPolicy)
+      # that allows writing to our bucket. Doing this in case auxillary data required elsewhere
+      - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
       - !Ref AccessS3ManagedPolicy
       - !Ref AccessQueuesManagedPolicy
       - !Ref SubmitJobsManagedPolicy

--- a/rios/parallel/aws/templates/batch.yaml
+++ b/rios/parallel/aws/templates/batch.yaml
@@ -144,6 +144,31 @@ Resources:
                 }
             ]
           }
+
+  # another repo that the user can copy 'main' docker images with their main scripts
+  BatchRepositoryMain:
+    Type: AWS::ECR::Repository
+    Properties:
+      RepositoryName: !Join ['', [!Ref ServiceName, "ecrMain"]]
+      LifecyclePolicy:
+        LifecyclePolicyText: |
+          {
+            "rules": [
+                {
+                    "rulePriority": 1,
+                    "description": "Expire images older than 1 day",
+                    "selection": {
+                        "tagStatus": "untagged",
+                        "countType": "sinceImagePushed",
+                        "countUnit": "days",
+                        "countNumber": 1
+                    },
+                    "action": {
+                        "type": "expire"
+                    }
+                }
+            ]
+          }
        
   # An input queue for passing information from the main RIOS
   # script to the Batch workers 
@@ -164,7 +189,7 @@ Resources:
   BatchBucket:
     Type: AWS::S3::Bucket
     Properties:
-      BucketName: !Join ['', [!Ref ServiceName, bucket, !Ref AWS::AccountId]]
+      BucketName: !Join ['', [!Ref ServiceName, bucket, !Ref AWS::AccountId, !Ref AWS::Region]]
       
   # Ensure the workers have enough access to the S3 bucket
   AccessS3ManagedPolicy:
@@ -203,6 +228,24 @@ Resources:
           Resource:
             - !GetAtt BatchInQueue.Arn
             - !GetAtt BatchOutQueue.Arn
+            
+  # Allow jobs to submit other jobs. Handy in case the user
+  # runs their own 'main' script in the queue and wants to 
+  # fire off sub jobs
+  SubmitJobsManagedPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Policy for allowing jobs to submit other jobs
+      Path: /
+      PolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Action: 
+            - 'batch:SubmitJob'
+          Resource:
+            - !GetAtt BatchProcessingJobDefinition.Arn
+            - !GetAtt BatchProcessingJobQueue.Arn
       
   # Needed by AWS Batch.
   BatchServiceRole:
@@ -241,6 +284,7 @@ Resources:
       - arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess
       - !Ref AccessS3ManagedPolicy
       - !Ref AccessQueuesManagedPolicy
+      - !Ref SubmitJobsManagedPolicy
   # The worker job. Set the S3 bucket and SQS queues info in the 
   # enironment.
   BatchProcessingJobDefinition:
@@ -250,6 +294,23 @@ Resources:
       JobDefinitionName: !Join ['', [!Ref ServiceName, "JobDefinition"]]
       ContainerProperties:
         Image: !Join ['', [!GetAtt BatchRepository.RepositoryUri, ":latest"]]
+        Vcpus: !Ref VCPUS
+        Memory: !Ref MaxMemory
+        Environment:
+          - Name: "RIOSBucket"
+            Value: !Ref BatchBucket
+          - Name: "RIOSInQueue"
+            Value: !Ref BatchInQueue
+          - Name: "RIOSOutQueue"
+            Value: !Ref BatchOutQueue
+  # job definition for the 'main' script
+  BatchProcessingJobDefinitionMain:
+    Type: AWS::Batch::JobDefinition
+    Properties:
+      Type: container
+      JobDefinitionName: !Join ['', [!Ref ServiceName, "JobDefinitionMain"]]
+      ContainerProperties:
+        Image: !Join ['', [!GetAtt BatchRepositoryMain.RepositoryUri, ":latest"]]
         Vcpus: !Ref VCPUS
         Memory: !Ref MaxMemory
         Environment:
@@ -308,8 +369,13 @@ Outputs:
   BatchProcessingJobDefinitionArn:
     Value:
       Ref: BatchProcessingJobDefinition
+  BatchProcessingJobDefinitionMainArn:
+    Value:
+      Ref: BatchProcessingJobDefinitionMain
   BatchProcessingJobDefinitionName:
     Value: !Join ['', [!Ref ServiceName, "JobDefinition"]]
+  BatchProcessingJobDefinitionMainName:
+    Value: !Join ['', [!Ref ServiceName, "JobDefinitionMain"]]
   BatchECR:
     Value: !GetAtt BatchRepository.RepositoryUri
   BatchInQueue:

--- a/rios/parallel/aws/templates/createbatch.py
+++ b/rios/parallel/aws/templates/createbatch.py
@@ -45,6 +45,8 @@ def getCmdArgs():
         help="Wait until CloudFormation is complete before exiting")
     p.add_argument('--modify', action="store_true",
         help="Instead of creating the stack, modify it.")
+    p.add_argument('--tag', default='RIOS', 
+        help="Tag to use when creating resources. (default=%(default)s)")
         
     cmdargs = p.parse_args()
     if cmdargs.az is not None and len(cmdargs.az) != 3:
@@ -61,7 +63,8 @@ def main():
     
     stackId, status = createBatch(cmdargs.stackname, cmdargs.region,
         cmdargs.az, cmdargs.ecrname, cmdargs.vcpus, 
-        cmdargs.mem, cmdargs.maxjobs, cmdargs.modify, cmdargs.wait)
+        cmdargs.mem, cmdargs.maxjobs, cmdargs.modify, cmdargs.wait,
+        cmdargs.tag)
             
     print('stackId: {}'.format(stackId))
     if status is not None:
@@ -78,7 +81,7 @@ def addParam(params, key, value):
 
     
 def createBatch(stackname, region, azs, ecrName, vCPUs, maxMem, maxJobs, 
-        modify, wait):
+        modify, wait, tag):
     """
     Do the work of creating the CloudFormation Stack
     """        
@@ -110,14 +113,14 @@ def createBatch(stackname, region, azs, ecrName, vCPUs, maxMem, maxJobs,
         # modify stack
         resp = client.update_stack(StackName=stackname,
             TemplateBody=body, Capabilities=['CAPABILITY_IAM'], 
-            Parameters=params)
+            Parameters=params, Tags=[{'Key': tag, 'Value': '1'}])
         inProgressStatus = 'UPDATE_IN_PROGRESS'
 
     else:
         # create stack
         resp = client.create_stack(StackName=stackname,
             TemplateBody=body, Capabilities=['CAPABILITY_IAM'], 
-            Parameters=params)
+            Parameters=params, Tags=[{'Key': tag, 'Value': '1'}])
         inProgressStatus = 'CREATE_IN_PROGRESS'
         
     stackId = resp['StackId']


### PR DESCRIPTION
This PR adds the following:

- Allow setting of the AWS Region used for creation of resources
- Insert the region in the bucket name so a user can have buckets in different regions without name clash
- A new ECR repo for the "main" script that actually contains the user's script. Building and pushing to this (along with the submission to Batch) is left as a task for the user. It seems more likely that users will want to run their "main" script as a Batch job rather than running locally.
- Permissions to allow submission of jobs so that the user's "main" script as a Batch job can then fire off worker jobs.
- Implement tags for users

In future I suspect it may be necessary to ensure that the "main" script has access to more local storage as you'd only be using this if you had very large files and by default Batch jobs don't have much local storage. This can be done by either adding a LaunchTemplate to the ComputeEnvironment that increases the size of the root volume, or my directly creating and mounting an EBS Volume. RIOS should probably do something here to make it easy, but I'll make that a separate PR.