### PR TITLE
Workaround for float images that are all the same value

### DIFF
--- a/rios/applier.py
+++ b/rios/applier.py
@@ -349,6 +349,8 @@ class ApplierControls(object):
         """
         Set the global default value to use as the 
         null value when calculating stats.
+        Setting this to None means there will be no null value in the 
+        stats calculations.
         """
         self.setOptionForImagename('statsIgnore', imagename, statsIgnore)
         

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -257,7 +257,7 @@ def addStatistics(ds, progress, ignore=None, approx_ok=False):
             histCalcMax = maxval
             if histCalcMin == histCalcMax:
                 histCalcMax = histCalcMax + 0.5
-                histmax = histCalcMax
+                histnbins = 1
             histstep = float(histCalcMax - histCalcMin) / histnbins
         # Note that the complex number data types are not handled, as I am not sure
         # what a histogram or a median would mean for such types. 

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -255,6 +255,9 @@ def addStatistics(ds, progress, ignore=None, approx_ok=False):
             tmpmeta["STATISTICS_HISTOBINFUNCTION"] = 'linear'
             histCalcMin = minval
             histCalcMax = maxval
+            if histCalcMin == histCalcMax:
+                histCalcMax = histCalcMax + 0.5
+                histmax = histCalcMax
             histstep = float(histCalcMax - histCalcMin) / histnbins
         # Note that the complex number data types are not handled, as I am not sure
         # what a histogram or a median would mean for such types. 


### PR DESCRIPTION
With recent versions of GDAL, if you create a float image that is all the same value you get a:
```
ERROR 5: /tmp/bob.img, band 1: dfMax should be strictly greater than dfMin
```

This used to be a warning, but is now an error. Turns out this is coming from the histogram calculation.

I know this is an unlikely situation in remote sensing, but pops up occasionally in spatial modelling.

The proposed workaround is to make the max 0.5 larger than the min. Not sure if this is the correct approach... 

Also amended the docstring for `controls.setStatsIgnore` to tell you how to unset the ignore value.