### PR TITLE
use GDAL's type conversion functions instead

### DIFF
--- a/rios/imageio.py
+++ b/rios/imageio.py
@@ -21,11 +21,9 @@ writing modules
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import numpy
-from osgeo import gdalconst
+import warnings
 from osgeo import gdal
-
-from . import rioserrors
+from osgeo import gdal_array
 
 INTERSECTION = 0
 UNION = 1
@@ -52,41 +50,14 @@ def pix2wld(transform, x, y):
     return Coord(geox, geoy)
 
 
-# Mappings between numpy datatypes and GDAL datatypes.
-# Note that ambiguities are resolved by the order - the first one found 
-# is the one chosen. 
-dataTypeMapping = [
-    (numpy.uint8, gdalconst.GDT_Byte),
-    (bool, gdalconst.GDT_Byte),
-    (numpy.int16, gdalconst.GDT_Int16),
-    (numpy.uint16, gdalconst.GDT_UInt16),
-    (numpy.int32, gdalconst.GDT_Int32),
-    (numpy.uint32, gdalconst.GDT_UInt32),
-    (numpy.float32, gdalconst.GDT_Float32),
-    (numpy.float64, gdalconst.GDT_Float64)
-]
-
-# hack for GDAL 3.5 and later which suppport 64 bit ints
-if hasattr(gdalconst, 'GDT_Int64'):
-    dataTypeMapping.append((numpy.int64, gdalconst.GDT_Int64))
-    dataTypeMapping.append((numpy.uint64, gdalconst.GDT_UInt64))
-
-# With GDAL 3.7, there is a plan to introduce GDT_Int8, so try to cope with it.
-# Hopefully OK, because we did not previously have anything to cope with arrays
-# of type numpy.int8.
-if hasattr(gdalconst, 'GDT_Int8'):
-    dataTypeMapping.append((numpy.int8, gdalconst.GDT_Int8))
-
-
 def GDALTypeToNumpyType(gdaltype):
     """
     Given a gdal data type returns the matching
     numpy data type
     """
-    for (numpy_type, test_gdal_type) in dataTypeMapping:
-        if test_gdal_type == gdaltype:
-            return numpy_type
-    raise rioserrors.TypeConversionError("Unknown GDAL datatype: %s"%gdaltype)
+    warnings.warn("Future versions of RIOS may remove this function. " +
+        "Use gdal_array.GDALTypeCodeToNumericTypeCode instead", DeprecationWarning)
+    return gdal_array.GDALTypeCodeToNumericTypeCode(gdaltype)
 
 
 def NumpyTypeToGDALType(numpytype):
@@ -94,7 +65,6 @@ def NumpyTypeToGDALType(numpytype):
     For a given numpy data type returns the matching
     GDAL data type
     """
-    for (test_numpy_type, gdaltype) in dataTypeMapping:
-        if test_numpy_type == numpytype:
-            return gdaltype
-    raise rioserrors.TypeConversionError("Unknown numpy datatype: %s"%numpytype)
+    warnings.warn("Future versions of RIOS may remove this function. " +
+        "Use gdal_array.NumericTypeCodeToGDALTypeCode instead", DeprecationWarning)
+    return gdal_array.NumericTypeCodeToGDALTypeCode(numpytype)

--- a/rios/imageio.py
+++ b/rios/imageio.py
@@ -56,7 +56,8 @@ def GDALTypeToNumpyType(gdaltype):
     numpy data type
     """
     warnings.warn("Future versions of RIOS may remove this function. " +
-        "Use gdal_array.GDALTypeCodeToNumericTypeCode instead", DeprecationWarning)
+        "Use gdal_array.GDALTypeCodeToNumericTypeCode instead",
+        DeprecationWarning, stacklevel=2)
     return gdal_array.GDALTypeCodeToNumericTypeCode(gdaltype)
 
 
@@ -66,5 +67,6 @@ def NumpyTypeToGDALType(numpytype):
     GDAL data type
     """
     warnings.warn("Future versions of RIOS may remove this function. " +
-        "Use gdal_array.NumericTypeCodeToGDALTypeCode instead", DeprecationWarning)
+        "Use gdal_array.NumericTypeCodeToGDALTypeCode instead",
+        DeprecationWarning, stacklevel=2)
     return gdal_array.NumericTypeCodeToGDALTypeCode(numpytype)

--- a/rios/imagewriter.py
+++ b/rios/imagewriter.py
@@ -25,8 +25,8 @@ import os
 import math
 
 from osgeo import gdal
+from osgeo import gdal_array
 
-from . import imageio
 from . import rioserrors
 from . import rat
 from . import calcstats
@@ -221,7 +221,7 @@ class ImageWriter(object):
             # get the number of bands out of the block
             (nbands, y, x) = firstblock.shape
             # and the datatype
-            gdaldatatype = imageio.NumpyTypeToGDALType(firstblock.dtype)
+            gdaldatatype = gdal_array.NumericTypeCodeToGDALTypeCode(firstblock.dtype)
 
         if creationoptions is None:
             if drivername in dfltDriverOptions:

--- a/rios/inputcollection.py
+++ b/rios/inputcollection.py
@@ -25,10 +25,10 @@ import os
 import sys
 import tempfile
 
-from . import imageio
 from . import rioserrors
 from . import pixelgrid
 from osgeo import gdal
+from osgeo import gdal_array
 
 
 class InputIterator(object):
@@ -134,7 +134,7 @@ class InputCollection(object):
                 
             # get the datatype of band 1
             gdaldatatype = ds.GetRasterBand(1).DataType
-            numpytype = imageio.GDALTypeToNumpyType(gdaldatatype)
+            numpytype = gdal_array.GDALTypeCodeToNumericTypeCode(gdaldatatype)
         
             # store the values in our lists
             self.imageList.append(image)

--- a/rios/readerinfo.py
+++ b/rios/readerinfo.py
@@ -24,6 +24,7 @@ read and info on the current block
 import math
 
 import numpy
+from osgeo import gdal_array
 
 from . import imageio
 
@@ -322,7 +323,7 @@ class ReaderInfo(object):
         # if there is a valid novalue, cast it to the type
         # of the dataset. Note this creates a numpy 0-d array
         if novalue is not None:
-            numpytype = imageio.GDALTypeToNumpyType(band.DataType)
+            numpytype = gdal_array.GDALTypeCodeToNumericTypeCode(band.DataType)
             novalue = numpy.cast[numpytype](novalue)
 
         return novalue

--- a/rios/vectorreader.py
+++ b/rios/vectorreader.py
@@ -29,10 +29,10 @@ from .imagewriter import DEFAULTCREATIONOPTIONS
 from . import rioserrors
 from . import cuiprogress
 from .imagereader import ImageReader
-from .imageio import NumpyTypeToGDALType
 from osgeo import ogr
 from osgeo import gdal
 from osgeo import osr
+from osgeo import gdal_array
 import numpy
 
 DEFAULTBURNVALUE = 1
@@ -259,7 +259,7 @@ class VectorReader(object):
                 # Haven't yet rasterized, so do this for the whole workingGrid
                 (nrows, ncols) = info.workingGrid.getDimensions()
                 numLayers = 1
-                gdaldatatype = NumpyTypeToGDALType(vector.datatype)
+                gdaldatatype = gdal_array.NumericTypeCodeToGDALTypeCode(vector.datatype)
                 outds = vector.driver.Create(vector.temp_image, ncols, nrows, numLayers, 
                     gdaldatatype, vector.driveroptions)
                 if outds is None:


### PR DESCRIPTION
of our own versions. Issue a `DeprecationWarning` if anyone tries to use these functions. You have to invoke Python with `-W error` to get these warnings of course, which is annoying.

Hasn't been heavily tested, but can you see any problems @neilflood ?