### PR TITLE
numpy.cast() replaced with numpy.asarray(), in prep for numpy-2.0

### DIFF
--- a/rios/readerinfo.py
+++ b/rios/readerinfo.py
@@ -397,7 +397,7 @@ class ReaderInfo(object):
         nullvalList = self.nullvalLookup[id(block)]
         nullval = nullvalList[band - 1]
         if nullval is not None:
-            nullval = numpy.cast[block.dtype](nullval)
+            nullval = numpy.asarray(nullval, dtype=block.dtype)
         return nullval
         
     def getPercent(self):


### PR DESCRIPTION
The check with ruff now gives
```
$ ruff check . --select NPY201
All checks passed!
```

Fixes #80 