### PR TITLE
Added future.pyprojects.toml. NOT to be used yet, see comments in file

### DIFF
--- a/future.pyprojects.toml
+++ b/future.pyprojects.toml
@@ -1,0 +1,47 @@
+# This currently fails if the installed versions of pip and setuptools
+# are too old (e.g. Ubuntu 22.04). These can be locally upgraded using
+#    pip install --user -U pip setuptools
+#
+# However, without that, the mere presence of this file as pyprojects.toml
+# will cause the install to fail. Not wishing to break existing recipes,
+# the file is currently named future.pyprojects.toml, until I work out
+# what to do.
+#
+
+[build-system]
+requires = ["setuptools"]
+
+[project]
+name = "rios"
+dynamic = ["version"]
+authors = [
+  {name = "Sam Gillingham"},
+  {name = "Neil Flood"}
+]
+description = "Raster Input/Output Simplification"
+readme = "README.md"
+license = {text = "LICENSE.txt"}
+
+[project.optional-dependencies]
+# For those computeWorkerKinds which run across multiple machines
+multimachine = ["cloudpickle"]
+
+# Currently allowing setuptools to "discover" the package directories,
+# but we could specify them if required, with [project]/packages=
+
+# The old setup.py currently has scripts=glob("bin/*.py"). When/if
+# we remove setup.py, we should also remove bin/, becuase the new
+# approach is via projects.scripts, which installs without the .py suffix
+
+[project.scripts]
+testrios = "rios.riostests.riostestutils:testAll"
+rioscalcstats = "rios.cmdline.rioscalcstats:main"
+riosprintstats = "rios.cmdline.riosprintstats:main"
+rios_computeworker = "rios.cmdline.rios_computeworker:mainCmd"
+
+[project.urls]
+Repository = "https://github.com/ubarsc/rios.git"
+Homepage = "https://www.rioshome.org"
+
+[tool.setuptools.dynamic]
+version = {attr = "rios.__version__"}


### PR DESCRIPTION
As noted in the file's comments, having this with its proper name would break existing recipes on older systems. I wanted to capture what I have learned, though, so here it is with a different name. Sigh......