### PR TITLE
ImageReader raises NotImplementedError 

### DIFF
--- a/rios/imagereader.py
+++ b/rios/imagereader.py
@@ -922,7 +922,7 @@ class ImageReader(object):
                 # set the relationship between numpy array
                 # and dataset in case the user needs the dataset object
                 # and/or the original filename
-                info.setBlockDataset(block, ds, image)
+                #info.setBlockDataset(block, ds, image)
                 
                 i += 1
                 
@@ -1071,4 +1071,3 @@ class ImageReader(object):
         Closes all open datasets
         """
         self.inputs.close()
-

--- a/rios/imagereader.py
+++ b/rios/imagereader.py
@@ -918,11 +918,6 @@ class ImageReader(object):
 
                 # add this block to our list
                 blockList.append(block)
-            
-                # set the relationship between numpy array
-                # and dataset in case the user needs the dataset object
-                # and/or the original filename
-                #info.setBlockDataset(block, ds, image)
                 
                 i += 1
                 


### PR DESCRIPTION
Commented out a call to ReaderInfo setBlockDataset, which has been refactored to produce a NotImplementedError, and therefore, anything using the ImageReader class cannot run.

I noticed that ImageReader has been deprecated and I will rework the few functions in RSGISLib which use this class. I ran the RSGISLib test suite with this line commented out and the tests passed so I think things are working OK without this function call but @gillins and @neilflood you'll know better than me 😄 