### PR TITLE
actually install RIOS into /usr/local as the entrypoint requires it

### DIFF
--- a/tools/awsbatch/Dockerfile
+++ b/tools/awsbatch/Dockerfile
@@ -35,6 +35,9 @@ RUN cd /tmp && tar xf rios-$RIOS_VER.tar.gz \
     && DEB_PYTHON_INSTALL_LAYOUT=deb_system pip install --prefix /usr/local . \
     && cd .. && rm -rf rios-$RIOS_VER rios-$RIOS_VER.tar.gz
 
+# So we can find rios installed in /usr/local
+ENV PYTHONPATH=/usr/local/lib/python3/dist-packages
+
 # Set our subproc script for AWS Batch as the entrypoint.
 ENTRYPOINT ["/usr/bin/python3", "/usr/local/bin/rios_computeworker"]
 

--- a/tools/awsbatch/Dockerfile
+++ b/tools/awsbatch/Dockerfile
@@ -32,7 +32,7 @@ COPY rios-$RIOS_VER.tar.gz /tmp
 # install RIOS
 RUN cd /tmp && tar xf rios-$RIOS_VER.tar.gz \
     && cd rios-$RIOS_VER \
-    && DEB_PYTHON_INSTALL_LAYOUT=deb_system pip install . \
+    && DEB_PYTHON_INSTALL_LAYOUT=deb_system pip install --prefix /usr/local . \
     && cd .. && rm -rf rios-$RIOS_VER rios-$RIOS_VER.tar.gz
 
 # Set our subproc script for AWS Batch as the entrypoint.


### PR DESCRIPTION
For CW_AWSBATCH. Not sure why this worked at one stage, but defaults to `/usr` now.