### PR TITLE
report usage for compute workers

### DIFF
--- a/rios/cmdline/rios_computeworker.py
+++ b/rios/cmdline/rios_computeworker.py
@@ -3,6 +3,7 @@
 Main script for a compute worker running in a separate process.
 """
 import argparse
+import resource
 
 from osgeo import gdal
 
@@ -101,6 +102,9 @@ def riosRemoteComputeWorker(workerID, host, port, authkey):
         # Send a printable version of the exception back to main thread
         workerErr = WorkerErrorRecord(e, 'compute', workerID)
         dataChan.exceptionQue.put(workerErr)
+
+    maxMem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    print("Maximum memory use of compute worker: {}Kb".format(maxMem))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@neilflood any thoughts on this? Is there a better way of doing this?

The problem is that for Batch (and SLURM etc no doubt) you have to say ahead of time how much memory you are going to be using. There is no real way to do this apart from running with heaps of mem on a subset and seeing how much you use (with this PR). Then refine the amount you ask for and go from there.