### PR TITLE
Split main and worker queues. Allow storage to be overridden

### DIFF
--- a/doc/source/awsbatch.rst
+++ b/doc/source/awsbatch.rst
@@ -81,7 +81,7 @@ The above is a simple way to get started with the AWS Batch support in RIOS. How
 that most users will need to run RIOS inside their own VPC. Doing so should be straightforward as long as the 
 following steps are followed:
 
-#. To resduce confusion, create separate ECR repositories for the 'main' and worker jobs
+#. To reduce confusion, create separate ECR repositories for the 'main' and worker jobs
 #. Ensure that your jobs have internet access - this is needed for Batch jobs to start. It is recommended
 to have your jobs running in a private subnet as shown in the example stack. You will need a NAT for internet
 access in this situation.

--- a/doc/source/awsbatch.rst
+++ b/doc/source/awsbatch.rst
@@ -72,3 +72,26 @@ to the CloudFormation, the ``jobQueue`` will be ``riosJobQueue`` and the ``jobDe
 
 This main script should then spawn other AWS Batch jobs that will stay running until the processing is
 finished.
+
+
+Adapting to your own needs
+--------------------------
+
+The above is a simple way to get started with the AWS Batch support in RIOS. However it is likely
+that most users will need to run RIOS inside their own VPC. Doing so should be straightforward as long as the 
+following steps are followed:
+
+#. To resduce confusion, create separate ECR repositories for the 'main' and worker jobs
+#. Ensure that your jobs have internet access - this is needed for Batch jobs to start. It is recommended
+to have your jobs running in a private subnet as shown in the example stack. You will need a NAT for internet
+access in this situation.
+#. Create an S3 endpoint so that S3 access is free for your jobs.
+#. Ensure that your stack has the following outputs: BatchProcessingJobQueueName, BatchProcessingJobDefinitionName,
+BatchVCPUS and BatchMaxVCPUS. These should refer to the queue and job definition for the workers.
+#. Ensure the `RIOS_AWSBATCH_STACK` and `RIOS_AWSBATCH_REGION` environment variables are set
+in the main script so that RIOS can start the worker jobs using the above stack outputs. 
+#. Ensure that the security group that your jobs run as (both worker and main) allows TCP traffic
+in the port range 30000-50000 from itself. Note this is not enabled in AWS by default.
+#. Ensure your main jobs have enough storage attached if writing large output files.
+#. Make sure you experiment with different EC2 instance types for your job. Performance and 
+price will differ between these types.

--- a/tools/awsbatch/batch.yaml
+++ b/tools/awsbatch/batch.yaml
@@ -227,24 +227,6 @@ Resources:
             - !Sub 'arn:aws:batch:${AWS::Region}:${AWS::AccountId}:job-queue/*'
             - !Sub 'arn:aws:batch:${AWS::Region}:${AWS::AccountId}:job-definition/*'
       
-  # Needed by AWS Batch.
-  BatchServiceRole:
-    Type: AWS::IAM::Role
-    Properties:
-      AssumeRolePolicyDocument:
-        Version: '2012-10-17'
-        Statement:
-        - Effect: Allow
-          Principal:
-            Service: batch.amazonaws.com
-          Action: sts:AssumeRole
-      ManagedPolicyArns:
-      - arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole
-  IamInstanceProfile:
-    Type: AWS::IAM::InstanceProfile
-    Properties:
-      Roles:
-      - Ref: EcsInstanceRole
   # This is the user that the batch workers run as.
   # Ensure we attach all the permissions it will need.
   EcsInstanceRole:
@@ -332,8 +314,6 @@ Resources:
         - !Ref BatchSecurityGroup
         InstanceRole:
           Ref: IamInstanceProfile
-      ServiceRole:
-        Ref: BatchServiceRole
   # Same as ComputeEnvironmentWorker but has a potentially larger
   # storage for saving large outputs - see the launch template
   ComputeEnvironmentMain:
@@ -357,8 +337,6 @@ Resources:
         LaunchTemplate:
           LaunchTemplateId: !Ref LaunchTemplate
           Version: !GetAtt LaunchTemplate.LatestVersionNumber
-      ServiceRole:
-        Ref: BatchServiceRole
   # Launch template - increase default storage available
   # https://repost.aws/knowledge-center/batch-job-failure-disk-space
   # https://docs.aws.amazon.com/batch/latest/userguide/launch-templates.html

--- a/tools/awsbatch/batch.yaml
+++ b/tools/awsbatch/batch.yaml
@@ -1,8 +1,8 @@
 ---
 # Create all the infrastructure for AWS Batch with RIOS
 # This includes its own VPC, subnets and security group.
-# These subnets are spread accross the first 3 availibality zones
-# For the Region.
+# These subnets are spread accross the first 3 availability zones
+# for the Region.
 # Private and public subnets are created with a NAT in the first
 # public subnet so the private subnets have internet access 
 # which is a requirement for Batch.

--- a/tools/awsbatch/batch.yaml
+++ b/tools/awsbatch/batch.yaml
@@ -43,11 +43,6 @@ Resources:
       # Below needed for Batch it seems
       EnableDnsSupport: 'true'
       EnableDnsHostnames: 'true'
-      # make all instances launch on dedicated hardware
-      # when this is 'default' instances are shared
-      # making compute intensive job performance quite 
-      # unpredictible
-      InstanceTenancy: 'dedicated'
   # Create a subnet for each availability zone
   BatchSubnet1:
     Type: AWS::EC2::Subnet

--- a/tools/awsbatch/batch.yaml
+++ b/tools/awsbatch/batch.yaml
@@ -292,13 +292,6 @@ Resources:
           - Name: "RIOS_AWSBATCH_REGION"
             Value: !Ref "AWS::Region"
 
-  # Because all the jobs are communicating together (when computeWorkers > 0)
-  # place them all in the same availability zone
-  BatchPlacementGroup:
-    Type: AWS::EC2::PlacementGroup
-    Properties:
-      Strategy: cluster
-
   # Our queues - a different one for 'main' jobs
   # as they usually need a different compute environment
   # with more storage.
@@ -339,7 +332,6 @@ Resources:
         - !Ref BatchSecurityGroup
         InstanceRole:
           Ref: IamInstanceProfile
-        PlacementGroup: !Ref BatchPlacementGroup
       ServiceRole:
         Ref: BatchServiceRole
   # Same as ComputeEnvironmentWorker but has a potentially larger
@@ -362,7 +354,6 @@ Resources:
         - !Ref BatchSecurityGroup
         InstanceRole:
           Ref: IamInstanceProfile
-        PlacementGroup: !Ref BatchPlacementGroup
         LaunchTemplate:
           LaunchTemplateId: !Ref LaunchTemplate
           Version: !GetAtt LaunchTemplate.LatestVersionNumber

--- a/tools/awsbatch/batch.yaml
+++ b/tools/awsbatch/batch.yaml
@@ -1,8 +1,13 @@
 ---
 # Create all the infrastructure for AWS Batch with RIOS
 # This includes its own VPC, subnets and security group.
-# These subnets are spread accross the first 3 availibility zones
+# These subnets are spread accross the first 3 availibality zones
 # For the Region.
+# Private and public subnets are created with a NAT in the first
+# public subnet so the private subnets have internet access 
+# which is a requirement for Batch.
+# An endpoint is created for S3 so S3 file access does not go
+# through the NAT.
 # Also created is an ECR for saving the docker image that is used for processing,
 #
 # Use the script createbatch.py for stack creation and modification.
@@ -43,39 +48,63 @@ Resources:
       # Below needed for Batch it seems
       EnableDnsSupport: 'true'
       EnableDnsHostnames: 'true'
-  # Create a subnet for each availability zone
-  BatchSubnet1:
+  # Create a public subnet for each availability zone
+  BatchPublicSubnet1:
     Type: AWS::EC2::Subnet
     Properties:
+      CidrBlock: 10.0.0.0/24
       VpcId:
         Ref: BatchVPC
-      # yes we do need public ips or NAT
-      # See https://repost.aws/knowledge-center/batch-job-stuck-runnable-status
-      MapPublicIpOnLaunch: true
-      CidrBlock: 10.0.0.0/24
       AvailabilityZone: !Select 
         - 0
         - Fn::GetAZs: !Ref 'AWS::Region'
-  BatchSubnet2:
+  BatchPublicSubnet2:
     Type: AWS::EC2::Subnet
     Properties:
+      CidrBlock: 10.0.1.0/24
       VpcId:
         Ref: BatchVPC
-      MapPublicIpOnLaunch: true
-      CidrBlock: 10.0.1.0/24
       AvailabilityZone: !Select 
         - 1
         - Fn::GetAZs: !Ref 'AWS::Region'
-  BatchSubnet3:
+  BatchPublicSubnet3:
     Type: AWS::EC2::Subnet
     Properties:
+      CidrBlock: 10.0.2.0/24
       VpcId:
         Ref: BatchVPC
-      MapPublicIpOnLaunch: true
-      CidrBlock: 10.0.2.0/24
       AvailabilityZone: !Select 
         - 2
         - Fn::GetAZs: !Ref 'AWS::Region'
+  # Create a private subnet for each availability zone
+  BatchPrivateSubnet1:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.0.10.0/24
+      VpcId:
+        Ref: BatchVPC
+      AvailabilityZone: !Select 
+        - 0
+        - Fn::GetAZs: !Ref 'AWS::Region'
+  BatchPrivateSubnet2:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.0.11.0/24
+      VpcId:
+        Ref: BatchVPC
+      AvailabilityZone: !Select 
+        - 1
+        - Fn::GetAZs: !Ref 'AWS::Region'
+  BatchPrivateSubnet3:
+    Type: AWS::EC2::Subnet
+    Properties:
+      CidrBlock: 10.0.12.0/24
+      VpcId:
+        Ref: BatchVPC
+      AvailabilityZone: !Select 
+        - 2
+        - Fn::GetAZs: !Ref 'AWS::Region'
+
   # A security group for everything to run as
   BatchSecurityGroup:
     Type: AWS::EC2::SecurityGroup
@@ -99,7 +128,15 @@ Resources:
   # They need to talk to ECS/CloudWatch. 
   # Create an endpoint for S3 so traffic doesn't need to go through 
   # the internet gateway (and cost)
-  RouteTable:
+  PublicRouteTable1:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref BatchVPC
+  PublicRouteTable2:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref BatchVPC
+  PublicRouteTable3:
     Type: "AWS::EC2::RouteTable"
     Properties:
       VpcId: !Ref BatchVPC
@@ -110,12 +147,111 @@ Resources:
     Properties:
       VpcId: !Ref BatchVPC
       InternetGatewayId: !Ref InternetGateway
-  InternetRoute:
-    Type: "AWS::EC2::Route"
-    Properties:
-      DestinationCidrBlock: "0.0.0.0/0"
+
+  RoutePublicGateway1:
+   DependsOn: InternetGateway
+   Type: AWS::EC2::Route
+   Properties:
+      RouteTableId: !Ref PublicRouteTable1
+      DestinationCidrBlock: '0.0.0.0/0'
       GatewayId: !Ref InternetGateway
-      RouteTableId: !Ref RouteTable
+  RoutePublicGateway2:
+   DependsOn: InternetGateway
+   Type: AWS::EC2::Route
+   Properties:
+      RouteTableId: !Ref PublicRouteTable2
+      DestinationCidrBlock: '0.0.0.0/0'
+      GatewayId: !Ref InternetGateway
+  RoutePublicGateway3:
+   DependsOn: InternetGateway
+   Type: AWS::EC2::Route
+   Properties:
+      RouteTableId: !Ref PublicRouteTable3
+      DestinationCidrBlock: '0.0.0.0/0'
+      GatewayId: !Ref InternetGateway
+
+  # Associate the public route table with each subnet
+  PublicSubnet1RouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      RouteTableId: !Ref PublicRouteTable1
+      SubnetId: !Ref BatchPublicSubnet1
+  PublicSubnet2RouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      RouteTableId: !Ref PublicRouteTable2
+      SubnetId: !Ref BatchPublicSubnet2
+  PublicSubnet3RouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      RouteTableId: !Ref PublicRouteTable3
+      SubnetId: !Ref BatchPublicSubnet3
+
+  # NAT each private subnet
+  PrivateRouteTable1:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref BatchVPC
+  PrivateRouteTable2:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref BatchVPC
+  PrivateRouteTable3:
+    Type: "AWS::EC2::RouteTable"
+    Properties:
+      VpcId: !Ref BatchVPC
+
+  # NAT gateway in first AZ      
+  NATGatewayEIP1:
+   DependsOn: BatchVPC
+   Type: AWS::EC2::EIP
+   Properties:
+      Domain: vpc
+  NATGateway1:
+   Type: AWS::EC2::NatGateway
+   Properties:
+      AllocationId: !GetAtt NATGatewayEIP1.AllocationId
+      SubnetId: !Ref BatchPublicSubnet1
+
+  RouteNATGateway1:
+   DependsOn: NATGateway1
+   Type: AWS::EC2::Route
+   Properties:
+      RouteTableId: !Ref PrivateRouteTable1
+      DestinationCidrBlock: '0.0.0.0/0'
+      NatGatewayId: !Ref NATGateway1
+  RouteNATGateway2:
+   DependsOn: NATGateway1
+   Type: AWS::EC2::Route
+   Properties:
+      RouteTableId: !Ref PrivateRouteTable2
+      DestinationCidrBlock: '0.0.0.0/0'
+      NatGatewayId: !Ref NATGateway1
+  RouteNATGateway3:
+   DependsOn: NATGateway1
+   Type: AWS::EC2::Route
+   Properties:
+      RouteTableId: !Ref PrivateRouteTable3
+      DestinationCidrBlock: '0.0.0.0/0'
+      NatGatewayId: !Ref NATGateway1
+
+  # Associate the private route table with each subnet
+  PrivateSubnet1RouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable1
+      SubnetId: !Ref BatchPrivateSubnet1
+  PrivateSubnet2RouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable2
+      SubnetId: !Ref BatchPrivateSubnet2
+  PrivateSubnet3RouteTableAssociation:
+    Type: "AWS::EC2::SubnetRouteTableAssociation"
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable3
+      SubnetId: !Ref BatchPrivateSubnet3
+
 
   # Allow S3 traffic to go through an internet gateway
   S3GatewayEndpoint:
@@ -136,24 +272,9 @@ Resources:
                - 'arn:aws:s3:::*/*'
                - 'arn:aws:s3:::*'
       RouteTableIds:
-        - !Ref RouteTable
-
-  # Associate the route table with each subnet
-  Subnet1RouteTableAssociation:
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
-    Properties:
-      RouteTableId: !Ref RouteTable
-      SubnetId: !Ref BatchSubnet1
-  Subnet2RouteTableAssociation:
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
-    Properties:
-      RouteTableId: !Ref RouteTable
-      SubnetId: !Ref BatchSubnet2
-  Subnet3RouteTableAssociation:
-    Type: "AWS::EC2::SubnetRouteTableAssociation"
-    Properties:
-      RouteTableId: !Ref RouteTable
-      SubnetId: !Ref BatchSubnet3
+        - !Ref PrivateRouteTable1
+        - !Ref PrivateRouteTable2
+        - !Ref PrivateRouteTable3
 
   # Create an ECR to hold the image that contains RIOS
   # (and any other packages the function needs)
@@ -227,6 +348,11 @@ Resources:
             - !Sub 'arn:aws:batch:${AWS::Region}:${AWS::AccountId}:job-queue/*'
             - !Sub 'arn:aws:batch:${AWS::Region}:${AWS::AccountId}:job-definition/*'
       
+  IamInstanceProfile:
+    Type: AWS::IAM::InstanceProfile
+    Properties:
+      Roles:
+      - Ref: EcsInstanceRole
   # This is the user that the batch workers run as.
   # Ensure we attach all the permissions it will need.
   EcsInstanceRole:
@@ -307,9 +433,9 @@ Resources:
         InstanceTypes:
         - !Ref InstanceType
         Subnets:
-        - !Ref BatchSubnet1
-        - !Ref BatchSubnet2
-        - !Ref BatchSubnet3
+        - !Ref BatchPrivateSubnet1
+        - !Ref BatchPrivateSubnet2
+        - !Ref BatchPrivateSubnet3
         SecurityGroupIds:
         - !Ref BatchSecurityGroup
         InstanceRole:
@@ -327,9 +453,9 @@ Resources:
         InstanceTypes:
         - !Ref InstanceType
         Subnets:
-        - !Ref BatchSubnet1
-        - !Ref BatchSubnet2
-        - !Ref BatchSubnet3
+        - !Ref BatchPrivateSubnet1
+        - !Ref BatchPrivateSubnet2
+        - !Ref BatchPrivateSubnet3
         SecurityGroupIds:
         - !Ref BatchSecurityGroup
         InstanceRole:

--- a/tools/awsbatch/batch.yaml
+++ b/tools/awsbatch/batch.yaml
@@ -27,6 +27,9 @@ Parameters:
   InstanceType:
     Type: String
     Default: optimal  # for x86. Use m7g etc for Gravitron
+  MainVolumeSize:
+    Type: Number
+    Default: 32  # increase if you run out of space with 'main' jobs
   
 Resources:
   # Create our own vpc for resources so we are separate
@@ -301,18 +304,29 @@ Resources:
     Properties:
       Strategy: cluster
 
-  # Our queue
-  BatchProcessingJobQueue:
+  # Our queues - a different one for 'main' jobs
+  # as they usually need a different compute environment
+  # with more storage.
+  BatchProcessingJobQueueWorker:
     Type: AWS::Batch::JobQueue
     Properties:
-      JobQueueName: !Sub '${ServiceName}JobQueue'
+      JobQueueName: !Sub '${ServiceName}JobQueueWorker'
       Priority: 1
       ComputeEnvironmentOrder:
       - Order: 1
         ComputeEnvironment:
-          Ref: ComputeEnvironment
+          Ref: ComputeEnvironmentWorker
+  BatchProcessingJobQueueMain:
+    Type: AWS::Batch::JobQueue
+    Properties:
+      JobQueueName: !Sub '${ServiceName}JobQueueMain'
+      Priority: 1
+      ComputeEnvironmentOrder:
+      - Order: 1
+        ComputeEnvironment:
+          Ref: ComputeEnvironmentMain
   # Compute Environment - set subnets and security group etc.
-  ComputeEnvironment:
+  ComputeEnvironmentWorker:
     Type: AWS::Batch::ComputeEnvironment
     Properties:
       Type: MANAGED
@@ -333,6 +347,45 @@ Resources:
         PlacementGroup: !Ref BatchPlacementGroup
       ServiceRole:
         Ref: BatchServiceRole
+  # Same as ComputeEnvironmentWorker but has a potentially larger
+  # storage for saving large outputs - see the launch template
+  ComputeEnvironmentMain:
+    Type: AWS::Batch::ComputeEnvironment
+    Properties:
+      Type: MANAGED
+      ComputeResources:
+        Type: EC2
+        MinvCpus: 0
+        MaxvCpus: !Ref MaxVCPUS
+        InstanceTypes:
+        - !Ref InstanceType
+        Subnets:
+        - !Ref BatchSubnet1
+        - !Ref BatchSubnet2
+        - !Ref BatchSubnet3
+        SecurityGroupIds:
+        - !Ref BatchSecurityGroup
+        InstanceRole:
+          Ref: IamInstanceProfile
+        PlacementGroup: !Ref BatchPlacementGroup
+        LaunchTemplate:
+          LaunchTemplateId: !Ref LaunchTemplate
+          Version: !GetAtt LaunchTemplate.LatestVersionNumber
+      ServiceRole:
+        Ref: BatchServiceRole
+  # Launch template - increase default storage available
+  # https://repost.aws/knowledge-center/batch-job-failure-disk-space
+  # https://docs.aws.amazon.com/batch/latest/userguide/launch-templates.html
+  LaunchTemplate:
+    Type: AWS::EC2::LaunchTemplate
+    Properties:
+      LaunchTemplateData:
+         BlockDeviceMappings:
+           - DeviceName: /dev/xvda
+             Ebs:
+               VolumeType: gp2
+               VolumeSize: !Ref MainVolumeSize
+               DeleteOnTermination: true
      
 # Outputs that the main script can queury to find
 # the names and paths of things.
@@ -342,12 +395,20 @@ Outputs:
       Ref: BatchVPC
   ComputeEnvironmentArn:
     Value:
-      Ref: ComputeEnvironment
+      Ref: ComputeEnvironmentWorker
+  ComputeEnvironmentMainArn:
+    Value:
+      Ref: ComputeEnvironmentMain
   BatchProcessingJobQueueArn:
     Value:
-      Ref: BatchProcessingJobQueue
+      Ref: BatchProcessingJobQueueWorker
+  BatchProcessingJobQueueMainArn:
+    Value:
+      Ref: BatchProcessingJobQueueMain
   BatchProcessingJobQueueName:
-    Value: !Sub '${ServiceName}JobQueue'
+    Value: !Sub '${ServiceName}JobQueueWorker'
+  BatchProcessingJobQueueNameMain:
+    Value: !Sub '${ServiceName}JobQueueMain'
   BatchProcessingJobDefinitionArn:
     Value:
       Ref: BatchProcessingJobDefinition

--- a/tools/awsbatch/createbatch.py
+++ b/tools/awsbatch/createbatch.py
@@ -41,6 +41,8 @@ def getCmdArgs():
     p.add_argument('--instancetype', 
         help="Override the instance type for the jobs. This " +
             "needs to be the same architecture as the Docker images")
+    p.add_argument('--mainvolumesize', type=int, 
+        help="Override the main job volume size in GB")
     p.add_argument('--wait', action="store_true",
         help="Wait until CloudFormation is complete before exiting")
     p.add_argument('--modify', action="store_true",
@@ -61,7 +63,8 @@ def main():
     
     stackId, status = createBatch(cmdargs.stackname, cmdargs.region,
         cmdargs.ecrname, cmdargs.vcpus, cmdargs.mem, cmdargs.maxvcpus, 
-        cmdargs.instancetype, cmdargs.modify, cmdargs.wait, cmdargs.tag)
+        cmdargs.instancetype, cmdargs.mainvolumesize, cmdargs.modify, 
+        cmdargs.wait, cmdargs.tag)
             
     print('stackId: {}'.format(stackId))
     if status is not None:
@@ -78,7 +81,7 @@ def addParam(params, key, value):
 
     
 def createBatch(stackname, region, ecrName, vCPUs, maxMem, maxvCPUs, 
-        instanceType, modify, wait, tag):
+        instanceType, mainVolumeSize, modify, wait, tag):
     """
     Do the work of creating the CloudFormation Stack
     """        
@@ -100,6 +103,9 @@ def createBatch(stackname, region, ecrName, vCPUs, maxMem, maxvCPUs,
 
     if instanceType is not None:
         addParam(params, 'InstanceType', instanceType)
+
+    if mainVolumeSize is not None:
+        addParam(params, 'MainVolumeSize', str(mainVolumeSize))
         
     body = open('batch.yaml').read()
         


### PR DESCRIPTION
The main thing this PR adds the ability to increase the storage available for the 'main' worker. If creating large files this will be very useful as by default the local storage on a Batch worker is quite small.

To achieve this I needed to split the main and worker jobs into different ComputeEnvironments and thus different queues which may assist keeping everything separate.

I'm also considering allowing the placement group strategy to be overridden, but haven't done so yet. Please don't merge this until I've done some more testing.