### PR TITLE
Single-pass stats, pyramids, and histogram

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -29,7 +29,7 @@ jobs:
         miniforge-variant: Mambaforge
     - name: Install dependencies
       shell: bash -l {0}
-      run: conda install gdal cloudpickle scipy
+      run: conda install gdal libgdal-kea cloudpickle scipy
     - name: Test with testrios
       shell: bash -l {0}
       run: |

--- a/rios/applier.py
+++ b/rios/applier.py
@@ -589,7 +589,7 @@ class ApplierControls(object):
         not possible, it will be done at the end of processing, which will
         require an extra pass through each output file.
 
-        The single-pass histogram is only supported integer datatypes. The
+        The single-pass histogram is only supported for integer datatypes. The
         default behaviour is to do single-pass histograms if possible, and
         if not, to fall back computing histograms using GDAL's GetHistogram()
         function, after the output files have been written.

--- a/rios/applier.py
+++ b/rios/applier.py
@@ -217,18 +217,25 @@ class ApplierControls(object):
                     msg = msg.format(option, imagename)
                     raise ValueError(msg)
 
-        # Warn against use of approx stats with thematic output images
+        # Check output files for a number of conditions
         outImageList = [symbName for (symbName, seqNum, filename) in
             outfiles]
         outImageList = list(set(outImageList))
         for imagename in outImageList:
             thematic = self.getOptionForImagename('thematic', imagename)
             approxStats = self.getOptionForImagename('approxStats', imagename)
+            omitPyramids = self.getOptionForImagename('omitPyramids', imagename)
+
             if thematic and approxStats:
                 msg = ("Warning: Output image {} is thematic, and also " +
                        "uses approximate statistics. This is not " +
                        "recommended").format(imagename)
                 print(msg, file=sys.stderr)
+
+            if omitPyramids and approxStats:
+                msg = ("Approximate stats requires pyramid layers, " +
+                       "which have been omitted")
+                raise ValueError(msg)
 
     def setLoggingStream(self, loggingstream):
         """

--- a/rios/applier.py
+++ b/rios/applier.py
@@ -544,10 +544,16 @@ class ApplierControls(object):
         overviews) for output files as each block is computed. This avoids
         an extra pass through the data afterwards.
 
+        The single-pass pyramids requires that incremental writing of
+        pyramids is supported by the output format driver. This is checked
+        for each driver used. The default will use it if supported, but fall
+        back to GDAL if not.
+
         If singlePassPyramids is given here as False, then this will not be
         attempted, and instead GDAL's BuildOverviews() function will be called
         after the output is completed (i.e. a whole extra pass through the
-        data).
+        data). If True is given, and the driver does not support it, then
+        an exception will be raised.
 
         New in version 2.0.5.
 
@@ -583,12 +589,10 @@ class ApplierControls(object):
         not possible, it will be done at the end of processing, which will
         require an extra pass through each output file.
 
-        The single-pass histogram requires the ``numba`` package, and is
-        only supported for 8 and 16 bit integer datatypes. The default
-        behaviour is to do single-pass histograms if both these conditions
-        are satisfied, and if not, to fall back computing histograms using
-        GDAL's GetHistogram() function, after the output files have been
-        written.
+        The single-pass histogram is only supported integer datatypes. The
+        default behaviour is to do single-pass histograms if possible, and
+        if not, to fall back computing histograms using GDAL's GetHistogram()
+        function, after the output files have been written.
 
         If singlePassHistogram is given here as False, then GDAL's function
         will always be used. If singlePassHistogram is given here as True,

--- a/rios/applier.py
+++ b/rios/applier.py
@@ -964,6 +964,7 @@ def apply(userFunction, infiles, outfiles, otherArgs=None, controls=None):
                 otherArgs, controls, allInfo, workinggrid, blockList)
 
     rtn.timings.merge(timings)
+    rtn.workinggrid = workinggrid
 
     if not usingGdalExceptions:
         # Restore the calling program's preference
@@ -991,6 +992,7 @@ def apply_singleCompute(userFunction, infiles, outfiles, otherArgs,
     tmpfileMgr = TempfileManager(controls.tempdir)
     rasterizeMgr = RasterizationMgr()
     readWorkerMgr = None
+    singlePassMgr = None
     prog = None
     exceptionQue = None
     numBlocks = len(blockList)
@@ -1081,6 +1083,8 @@ def apply_singleCompute(userFunction, infiles, outfiles, otherArgs,
     rtn = ApplierReturn()
     rtn.timings = timings
     rtn.otherArgsList = [otherArgs]
+    if singlePassMgr is not None:
+        rtn.singlePassMgr = singlePassMgr
 
     return rtn
 
@@ -1183,6 +1187,7 @@ def apply_multipleCompute(userFunction, infiles, outfiles, otherArgs,
         rtn.timings.merge(t)
     rtn.otherArgsList = [obj for obj in computeMgr.outObjList
         if isinstance(obj, OtherInputs)]
+    rtn.singlePassMgr = singlePassMgr
 
     return rtn
 

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -88,13 +88,7 @@ def addPyramid(ds, progress,
     # Need to find out if we are thematic or continuous. 
     tmpmeta = ds.GetRasterBand(1).GetMetadata()
     if aggregationType is None:
-        if 'LAYER_TYPE' in tmpmeta:
-            if tmpmeta['LAYER_TYPE'] == 'athematic':
-                aggregationType = "AVERAGE"
-            else:
-                aggregationType = "NEAREST"
-        else:
-            aggregationType = DEFAULT_OVERVIEWAGGREGRATIONTYPE
+        aggregationType = DEFAULT_OVERVIEWAGGREGRATIONTYPE
     
     userdata = ProgressUserData()
     userdata.progress = progress

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -204,24 +204,27 @@ def addHistogramsGDAL(ds, minMaxList, approx_ok):
     for bandndx in range(ds.RasterCount):
         band = ds.GetRasterBand(bandndx + 1)
         (minval, maxval) = minMaxList[bandndx]
-        histParams = HistogramParams(band, minval, maxval)
+        if minval is not None:
+            histParams = HistogramParams(band, minval, maxval)
 
-        # Get histogram and force GDAL to recalculate it. Note that we use include_out_of_range=True,
-        # which is safe because we have calculated the histCalcMin/Max from the data. 
-        includeOutOfRange = True
-        hist = band.GetHistogram(histParams.calcMin,
-                    histParams.calcMax, histParams.nbins,
-                    includeOutOfRange, approx_ok)
-        # comes back as a list for some reason
-        hist = numpy.array(hist)
+            # Get histogram and force GDAL to recalculate it. Note that we
+            # use include_out_of_range=True, which is safe because we have
+            # calculated the histParams.calcMin/calcMax from the data.
+            includeOutOfRange = True
+            hist = band.GetHistogram(histParams.calcMin,
+                        histParams.calcMax, histParams.nbins,
+                        includeOutOfRange, approx_ok)
+            # comes back as a list for some reason
+            hist = numpy.array(hist)
 
-        # Check if GDAL's histogram code overflowed. This is not a fool-proof
-        # test, as some overflows will not result in negative counts. Since
-        # GDAL 3.x, it is no longer required, as counts are int64.
-        histogramOverflow = (hist.min() < 0)
-        
-        if not histogramOverflow:
-            writeHistogram(ds, band, hist, histParams)
+            # Check if GDAL's histogram code overflowed. This is not a
+            # fool-proof test, as some overflows will not result in negative
+            # counts. Since GDAL 3.x, it is no longer required, as counts
+            # are int64.
+            histogramOverflow = (hist.min() < 0)
+
+            if not histogramOverflow:
+                writeHistogram(ds, band, hist, histParams)
 
 
 def computeStatsGDAL(band, approx_ok):

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -756,9 +756,9 @@ class SinglePassAccumulator:
                 counts = counts[::-1]
         elif (havePos and haveNeg):
             nonzeroNdx = numpy.where(self.hist_neg > 0)[0]
-            minval = -(nonzeroNdx[-1])
+            minval = -(nonzeroNdx[-1] + 1)
             nonzeroNdx = numpy.where(self.hist_pos > 0)[0]
-            maxval = nonzeroNdx[1]
+            maxval = nonzeroNdx[-1]
             counts = numpy.concatenate([self.hist_neg[::-1], self.hist_pos])
 
         return (minval, maxval, counts)

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -787,22 +787,6 @@ class SinglePassAccumulator:
 
         return (minval, maxval, counts)
 
-    def histLimits(self):
-        """
-        Return the values which describe the limits of the histogram, 
-        i.e. the lowest and highest values with non-zero counts
-        """
-        nonzeroNdx = numpy.where(self.hist > 0)[0]
-        if len(nonzeroNdx) > 0:
-            first = nonzeroNdx[0]
-            last = nonzeroNdx[-1]
-            minval = self.histmin + first
-            maxval = self.histmin + last
-            nbins = last - first + 1
-        else:
-            minval = maxval = first = last = nbins = None
-        return (minval, maxval, first, last, nbins)
-
 
 def handleSinglePassActions(ds, arr, singlePassMgr, symbolicName, seqNum,
         xOff, yOff, timings):

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -418,7 +418,7 @@ class SinglePassManager:
         self.oviewAggtype = {}
         self.arrDtype = {}
         self.accumulators = {}
-        self.pyramidsSupported = {}
+        self.directPyramidsSupported = {}
 
         (nrows, ncols) = workinggrid.getDimensions()
         mindim = min(nrows, ncols)
@@ -445,7 +445,8 @@ class SinglePassManager:
 
             driverName = controls.getOptionForImagename('drivername',
                 symbolicName)
-            self.pyramidsSupported[symbolicName] = driverSupportsPyramids[driverName]
+            self.directPyramidsSupported[symbolicName] = (
+                driverSupportsPyramids[driverName])
 
             self.approxOK[symbolicName] = controls.getOptionForImagename(
                 'approxStats', symbolicName)
@@ -536,7 +537,7 @@ class SinglePassManager:
         """
         key = (symbolicName, self.PYRAMIDS)
         omit = self.omit[key]
-        supported = self.pyramidsSupported[symbolicName]
+        supported = self.directPyramidsSupported[symbolicName]
         spReq = self.singlePassRequested[key]
         aggType = self.oviewAggtype[symbolicName]
         if spReq is True and aggType not in self.supportedAggtypes:

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -109,7 +109,7 @@ def findOrCreateColumn(ratObj, usage, name, dtype):
     Returns the index of an existing column matched
     on usage. Creates it if not already existing using 
     the supplied name and dtype
-    Returns a tupe with index and a boolean specifying if 
+    Returns a tuple with index and a boolean specifying if 
     it is a new column or not
     """
     ncols = ratObj.GetColumnCount()

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -879,6 +879,8 @@ def writeHistogram(ds, band, hist, histParams):
     to calculate median and mode, and write them as well.
     """
     ratObj = band.GetDefaultRAT()
+    layerType = band.GetMetadataItem('LAYER_TYPE')
+    thematic = (layerType == "thematic")
     # The GDAL HFA driver has a bug in its SetLinearBinning function,
     # which was introduced as part of the RFC40 changes. Until
     # this is fixed and widely distributed, we should disable the use
@@ -886,12 +888,12 @@ def writeHistogram(ds, band, hist, histParams):
     driverName = ds.GetDriver().ShortName
     disableRFC40 = (driverName == 'HFA')
 
-    if ratObj is not None and not disableRFC40:
+    if thematic and ratObj is not None and not disableRFC40:
         histIndx, histNew = findOrCreateColumn(ratObj, gdal.GFU_PixelCount,
                                 "Histogram", gdal.GFT_Real)
         # write the hist in a single go
-        ratObj.SetRowCount(histParams.nbins)
-        ratObj.WriteArray(hist, histIndx)
+        ratObj.SetRowCount(histParams.nbins + int(histParams.min))
+        ratObj.WriteArray(hist, histIndx, start=int(histParams.min))
 
         ratObj.SetLinearBinning(histParams.min,
             (histParams.calcMax - histParams.calcMin) / histParams.nbins)

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -913,9 +913,12 @@ def writeHistogram(ds, band, hist, histParams):
     if thematic and ratObj is not None and not disableRFC40:
         histIndx, histNew = findOrCreateColumn(ratObj, gdal.GFU_PixelCount,
                                 "Histogram", gdal.GFT_Real)
-        # write the hist in a single go
-        ratObj.SetRowCount(histParams.nbins + int(histParams.min))
-        ratObj.WriteArray(hist, histIndx, start=int(histParams.min))
+        # Write the hist in a single go. Note that this only works because we
+        # have forced histParams.min to be zero, which is why we only
+        # do it this way for thematic cases. For other cases, the use of
+        # the RAT Histogram column is questionable.
+        ratObj.SetRowCount(histParams.nbins)
+        ratObj.WriteArray(hist, histIndx)
 
         ratObj.SetLinearBinning(histParams.min,
             (histParams.calcMax - histParams.calcMin) / histParams.nbins)

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -211,9 +211,8 @@ def addHistogramsGDAL(ds, minMaxList, approx_ok):
             # use include_out_of_range=True, which is safe because we have
             # calculated the histParams.calcMin/calcMax from the data.
             includeOutOfRange = True
-            hist = band.GetHistogram(histParams.calcMin,
-                        histParams.calcMax, histParams.nbins,
-                        includeOutOfRange, approx_ok)
+            hist = band.GetHistogram(histParams.calcMin, histParams.calcMax,
+                        histParams.nbins, includeOutOfRange, approx_ok)
             # comes back as a list for some reason
             hist = numpy.array(hist)
 

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -929,8 +929,8 @@ def writeHistogram(ds, band, hist, histParams):
         band.SetMetadataItem("STATISTICS_HISTOMAX", repr(histParams.max))
         band.SetMetadataItem("STATISTICS_HISTONUMBINS",
             repr(int(histParams.nbins)))
-        band.SetMetadataItem("STATISTICS_HISTOBINFUNCTION",
-            histParams.binFunction)
+
+    band.SetMetadataItem("STATISTICS_HISTOBINFUNCTION", histParams.binFunction)
 
     # estimate the median - bin with the middle number
     middlenum = hist.astype(numpy.int64).sum() / 2

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -133,6 +133,8 @@ if hasattr(gdal, 'GDT_Int64'):
     gdalLargeIntTypes.add(gdal.GDT_UInt64)
 
 gdalFloatTypes = set([gdal.GDT_Float32, gdal.GDT_Float64])
+numpyUnsignedIntTypes = (numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64)
+numpySignedIntTypes = (numpy.int8, numpy.int16, numpy.int32, numpy.int64)
 
 
 def addStatistics(ds, progress, ignore=None, approx_ok=False):
@@ -385,10 +387,6 @@ def setNullValue(ds, nullValue):
         band.SetNoDataValue(nullValue)
 
 
-unsignedIntTypes = (numpy.uint8, numpy.uint16, numpy.uint32, numpy.uint64)
-signedIntTypes = (numpy.int8, numpy.int16, numpy.int32, numpy.int64)
-
-
 class SinglePassManager:
     """
     The required info for dealing with single-pass pyramids/statistics/histogram.
@@ -410,7 +408,7 @@ class SinglePassManager:
         self.PYRAMIDS = 0
         self.STATISTICS = 1
         self.HISTOGRAM = 2
-        self.histSupportedDtypes = signedIntTypes + unsignedIntTypes
+        self.histSupportedDtypes = numpySignedIntTypes + numpyUnsignedIntTypes
         self.supportedAggtypes = ("NEAREST", )
 
         self.omit = {}
@@ -664,7 +662,7 @@ class SinglePassAccumulator:
         """
         Accumulate the histogram with counts from the given arr
         """
-        if (arr.dtype in unsignedIntTypes):
+        if (arr.dtype in numpyUnsignedIntTypes):
             counts = numpy.bincount(arr.flatten())
             if self.nullval is not None:
                 counts = self.removeNullFromCounts(counts, self.nullval)

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -743,6 +743,8 @@ class SinglePassAccumulator:
             if len(nonzeroNdx) > 0:
                 last = nonzeroNdx[-1]
                 counts = counts[:last + 1]
+            else:
+                counts = numpy.array([], dtype=counts.dtype)
         return counts
 
     def updateHist(self, newCounts, positive):

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -989,14 +989,4 @@ def linearHistFromDirect(desiredNbins, step, counts):
             j2 += 1
         newCounts[i] = counts[j1:j2].sum()
 
-    # Now adjust to exactly preserve the total. I don't think this is strictly
-    # necessary, but the perfectionist in me wants it to be so. (Maybe it should
-    # be an exception if (diff != 0) ???)
-    diff = counts.sum() - newCounts.sum()
-    # 'diff' is the amount we need to add to the newCounts to make the totals
-    # match. We add this to the bin with the largest count, where it will
-    # do the least damage.
-    ndx = numpy.argmax(newCounts)
-    newCounts[ndx] += diff
-
     return newCounts

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -85,8 +85,7 @@ def addPyramid(ds, progress,
         if (mindim // i) > minoverviewdim:
             nOverviews = nOverviews + 1
 
-    # Need to find out if we are thematic or continuous. 
-    tmpmeta = ds.GetRasterBand(1).GetMetadata()
+    # Need to find out if we are thematic or continuous.
     if aggregationType is None:
         aggregationType = DEFAULT_OVERVIEWAGGREGRATIONTYPE
     

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -726,7 +726,7 @@ class SinglePassAccumulator:
         numCounts = len(counts)
         if nullval < (numCounts - 1):
             counts[int(nullval)] = 0
-        else:
+        elif nullval == (numCounts - 1):
             # The null count is at the end, so find the next non-zero count,
             # and trim back to there. We don't need to trim from the start,
             # because of how numpy.bincount works.

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -64,9 +64,12 @@ def addPyramid(ds, progress,
     Adds Pyramid layers to the dataset. Adds levels until
     the raster dimension of the overview layer is < minoverviewdim,
     up to a maximum level controlled by the levels parameter. 
-    
+
+    Assumes that any desired null value has already been set on each
+    band of the Dataset.
+
     Uses gdal.Dataset.BuildOverviews() to do the work. 
-    
+
     """
     progress.setLabelText("Computing Pyramid Layers...")
     progress.setProgress(0)
@@ -143,12 +146,12 @@ def addStatistics(ds, progress, ignore=None, approx_ok=False):
     2.0.5, this function is no longer used directly with RIOS, and
     is maintained purely for backward compatibility with programs
     which call it directly.
-    
+
     Uses gdal.Band.ComputeStatistics() for mean, stddev, min and max,
     and gdal.Band.GetHistogram() to do histogram calculation. 
     The median and mode are estimated using the histogram, and so 
     for larger datatypes, they will be approximate only. 
-    
+
     For thematic layers, the histogram is calculated with as many bins 
     as required, for athematic integer and float types, a maximum
     of 256 bins is used.
@@ -178,6 +181,9 @@ def addBasicStatsGDAL(ds, approx_ok):
     much faster approximate statistics will be calculated (in particular,
     the min and max will only be approximate).
 
+    Assumes that any desired null value has already been set on each
+    band of the Dataset.
+
     Return a list of the minimum and maximum values for each band, in case
     this is required later for the histogram.
 
@@ -199,6 +205,9 @@ def addHistogramsGDAL(ds, minMaxList, approx_ok):
     function. If approx_ok is True, then much faster approximate histograms
     will be calculated (i.e. the pixel counts will be in proportion, but
     not exactly accurate).
+
+    Assumes that any desired null value has already been set on each
+    band of the Dataset.
 
     The minMaxList is as returned by addBasicStatsGDAL.
 

--- a/rios/imagewriter.py
+++ b/rios/imagewriter.py
@@ -209,8 +209,9 @@ def closeOutfiles(gdalOutObjCache, outfiles, controls, singlePassMgr, timings):
             progress = SilentProgress()
 
         ds = gdalOutObjCache[symbolicName, seqNum]
-        # Ensure that all data has been written
-        ds.FlushCache()
+        with timings.interval('writing'):
+            # Ensure that all data has been written
+            ds.FlushCache()
 
         if (not singlePassMgr.doSinglePassPyramids(symbolicName) and
                 not omitPyramids):

--- a/rios/riostests/riostestutils.py
+++ b/rios/riostests/riostestutils.py
@@ -272,7 +272,12 @@ def testAll():
     ok = teststats.run()
     if not ok:
         failureCount += 1
-    
+
+    from . import testpyramids
+    ok = testpyramids.run()
+    if not ok:
+        failureCount += 1
+
     from . import testrat
     ok = testrat.run()
     if not ok:

--- a/rios/riostests/riostestutils.py
+++ b/rios/riostests/riostestutils.py
@@ -88,12 +88,14 @@ def genRampArray(nRows=DEFAULT_ROWS, nCols=DEFAULT_COLS):
 
 
 def genRampImageFile(filename, reverse=False, xLeft=DEFAULT_XLEFT,
-        yTop=DEFAULT_YTOP, nullVal=None):
+        yTop=DEFAULT_YTOP, nullVal=None,
+        numRows=DEFAULT_ROWS, numCols=DEFAULT_COLS):
     """
     Generate a test image of a simple 2-d linear ramp. 
     """
-    ds = createTestFile(filename, xLeft=xLeft, yTop=yTop)
-    ramp = genRampArray()
+    ds = createTestFile(filename, xLeft=xLeft, yTop=yTop, numRows=numRows,
+        numCols=numCols)
+    ramp = genRampArray(nRows=numRows, nCols=numCols)
     if reverse:
         # Flip left-to-right
         ramp = ramp[:, ::-1]

--- a/rios/riostests/testpyramids.py
+++ b/rios/riostests/testpyramids.py
@@ -1,0 +1,122 @@
+"""
+Test that pyramid layers (i.e overviews) are written correctly, in both the
+single-pass and GDAL cases
+"""
+# This file is part of RIOS - Raster I/O Simplification
+# Copyright (C) 2012  Sam Gillingham, Neil Flood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+
+import numpy
+from osgeo import gdal
+
+from rios import applier
+
+from rios.riostests import riostestutils
+
+TESTNAME = 'TESTPYRAMIDS'
+
+
+def run():
+    """
+    Run tests of pyramid layers (i.e. overviews)
+    """
+    riostestutils.reportStart(TESTNAME)
+
+    allOK = True
+
+    # Create a test input file
+    rampInfile = 'ramp.img'
+    # Set a raster size which will result in exactly one pyramid layer
+    nRows = nCols = 1024
+    riostestutils.genRampImageFile(rampInfile, numRows=nRows, numCols=nCols)
+
+    infiles = applier.FilenameAssociations()
+    outfiles = applier.FilenameAssociations()
+    controls = applier.ApplierControls()
+
+    infiles.inimg = rampInfile
+    outfiles.outimg = "ramp.tif"
+    controls.setOutputDriverName("GTiff")
+
+    for singlePass in [True, False]:
+        controls.setSinglePassPyramids(singlePass)
+        applier.apply(doit, infiles, outfiles, controls=controls)
+        ok = checkPyramids(outfiles.outimg, singlePass)
+        allOK = allOK and ok
+
+    for filename in [rampInfile, outfiles.outimg]:
+        if os.path.exists(filename):
+            riostestutils.removeRasterFile(filename)
+
+    if allOK:
+        riostestutils.report(TESTNAME, "Passed")
+
+    return allOK
+
+
+def doit(info, inputs, outputs):
+    outputs.outimg = inputs.inimg
+
+
+def checkPyramids(filename, singlePass):
+    """
+    Check that the pyramids as written correspond to the base raster
+    in the file. If singlePass is True, then we should have centred the low-res
+    pixels, if it is False, then GDAL calculated them, and it appears not to
+    centre the low-res pixels (which I believe to be a bug).
+    """
+    ok = True
+
+    ds = gdal.Open(filename)
+    band = ds.GetRasterBand(1)
+    arr = band.ReadAsArray()
+    numOverviews = band.GetOverviewCount()
+    if numOverviews != 1:
+        msg = "Incorrect overview count: {}".format(numOverviews)
+        riostestutils.report(TESTNAME, msg)
+        ok = False
+
+    band_ov = band.GetOverview(0)
+    arr_ov = band_ov.ReadAsArray()
+
+    # Work out which offset (o) to use
+    factor = int(round(arr.shape[0] / arr_ov.shape[0]))
+    if singlePass:
+        o = int(round(factor / 2))
+    else:
+        # GDAL doesn't use an offset (sigh....)
+        o = 0
+
+    # The true sub-sampled overview array
+    true_arr_ov = arr[o::factor, o::factor]
+    if true_arr_ov.shape != arr_ov.shape:
+        msg = "Overview shape mis-match: {} != {}".format(true_arr_ov.shape,
+            arr_ov.shape)
+        riostestutils.report(TESTNAME, msg)
+        ok = False
+    else:
+        mismatch = (arr_ov != true_arr_ov)
+        numMismatch = numpy.count_nonzero(mismatch)
+        if numMismatch > 0:
+            msg = "Pyramid layer pixel mis-match for {} pixels".format(numMismatch)
+            riostestutils.report(TESTNAME, msg)
+            ok = False
+
+    return ok
+
+
+if __name__ == "__main__":
+    run()

--- a/rios/riostests/testratstats.py
+++ b/rios/riostests/testratstats.py
@@ -37,11 +37,10 @@ def run():
     
     allOK = True
 
-    imgfile = 'test.kea'
+    imgfile = 'test.img'
     nRows = 100
     nCols = 1
-    ds = riostestutils.createTestFile(imgfile, numRows=nRows, numCols=nCols,
-        driverName='KEA', creationOptions=[])
+    ds = riostestutils.createTestFile(imgfile, numRows=nRows, numCols=nCols)
     imgArray = numpy.ones((nRows, nCols), dtype=numpy.uint8)
     imgArray[1:10, 0] = numpy.arange(1, 10)
     imgArray[50:, 0] = 0

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -243,7 +243,9 @@ def runOneTest(driverName, creationOptions, fileDtype, scalefactor,
 
 def doit(info, inputs, outputs, otherargs):
     """
-    Re-write the input, with scaling and chabge of datatype
+    Called from RIOS.
+
+    Re-write the input, with scaling and change of datatype
     """
     dtype = otherargs.dtype
     outimg = inputs.inimg.astype(dtype) * otherargs.scale

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -149,7 +149,8 @@ def testForDriverAndType(driverName, creationOptions, fileDtype, scalefactor,
 
     # Force single-pass, with thematic output
     if fileDtype not in (hugeIntGDALTypes + floatGDALTypes):
-        print('single-pass/thematic', driverName, fileDtype)
+        print('single-pass/thematic', driverName, fileDtype, floatGDALTypes,
+            gdal.__version__)
         ok = ok and runOneTest(driverName, creationOptions, fileDtype,
             scalefactor, offset, rampInfile, ext, False, True, True)
 

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -96,6 +96,11 @@ def run():
             ok = testForDriverAndType(driverName, creationOptions,
                 fileDtype, scalefactor, rampInfile, ext)
             allOK = allOK and ok
+
+    # A simple test of omitting pyramids/stats/histogram
+    ok = runOneTest('KEA', [], gdal.GDT_Byte, 1, rampInfile, 'kea',
+        True, None, False)
+    allOK = allOK and ok
     
     if os.path.exists(rampInfile):
         riostestutils.removeRasterFile(rampInfile)
@@ -123,10 +128,6 @@ def testForDriverAndType(driverName, creationOptions, fileDtype, scalefactor,
     if fileDtype not in (hugeIntGDALTypes + floatGDALTypes):
         ok = runOneTest(driverName, creationOptions, fileDtype, scalefactor,
             rampInfile, ext, False, None, True)
-
-    # Omit pyramids/stats/histogram
-    ok = ok and runOneTest(driverName, creationOptions, fileDtype, scalefactor,
-        rampInfile, ext, True, None, False)
 
     # Force single-pass, with thematic output
     if fileDtype not in (hugeIntGDALTypes + floatGDALTypes):

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -148,8 +148,6 @@ def testForDriverAndType(driverName, creationOptions, fileDtype, scalefactor,
 
     # Force single-pass, with thematic output
     if fileDtype not in (hugeIntGDALTypes + floatGDALTypes):
-        print('single-pass/thematic', driverName, fileDtype, floatGDALTypes,
-            gdal.__version__)
         ok = ok and runOneTest(driverName, creationOptions, fileDtype,
             scalefactor, offset, rampInfile, ext, False, True, True)
 

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -413,10 +413,13 @@ def checkHistogram(band, imgArr, nullVal, iterationName):
             msgList.append("Histogram total count error: {} != {}".format(totalCount, trueTotalCount))
 
         # Test the individual counts, but only for "direct" binning
-        layerType = band.GetMetadataItem("LAYER_TYPE")
-        thematic = (layerType == "thematic")
-        if thematic or (imgArr.dtype == numpy.uint8):
+        binFunc = band.GetMetadataItem("STATISTICS_HISTOBINFUNCTION")
+        if binFunc == "direct":
+            histMin = int(band.GetMetadataItem("STATISTICS_HISTOMIN"))
             trueHist = numpy.bincount(imgArr[imgArr != nullVal])
+            # For athematic direct case, histMin may not be zero
+            trueHist = trueHist[histMin:]
+
             mismatch = (histVals != trueHist)
             if mismatch.any():
                 ok = False

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -158,7 +158,9 @@ def runOneTest(driverName, creationOptions, fileDtype, scalefactor, offset,
     """
     ok = True
 
-    nullVal = 0
+    # A random null value, so we don't rely on it being zero.
+    nullVal = 52 * scalefactor
+
     iterationName = "{} {} scale={} omit={} singlePass={} thematic={}".format(
         driverName, gdal.GetDataTypeName(fileDtype), scalefactor,
         omit, singlePass, thematic)
@@ -179,6 +181,7 @@ def runOneTest(driverName, creationOptions, fileDtype, scalefactor, offset,
     otherargs.dtype = arrDtype
     controls.setOutputDriverName(driverName)
     controls.setThematic(thematic)
+    controls.setStatsIgnore(nullVal)
     controls.setOmitPyramids(omit)
     controls.setOmitBasicStats(omit)
     controls.setOmitHistogram(omit)

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -128,7 +128,7 @@ def run():
 
 hugeIntGDALTypes = (gdal.GDT_Int32, gdal.GDT_UInt32)
 floatGDALTypes = (gdal.GDT_Float32,)
-if hasattr(gdal, 'GDT_Int64'):
+if VersionObj(gdal.__version__) >= VersionObj('3.5.2'):
     hugeIntGDALTypes += (gdal.GDT_Int64, gdal.GDT_UInt64)
     floatGDALTypes += (gdal.GDT_Float64,)
 

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -225,7 +225,8 @@ def runOneTest(driverName, creationOptions, fileDtype, scalefactor,
         riostestutils.report(TESTNAME, 
             'Iteration={}\n{}'.format(iterationName, msg))
         ok = False
-    elif omit and stats1 is not None:
+
+    if omit and stats1 is not None:
         msg = "Stats present, even though directed to omit"
         riostestutils.report(TESTNAME, 
             'Iteration={}\n{}'.format(iterationName, msg))

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -232,6 +232,7 @@ def runOneTest(driverName, creationOptions, fileDtype, scalefactor, offset,
     ds = gdal.Open(outfiles.outimg)
     band = ds.GetRasterBand(1)
     outarr = band.ReadAsArray()
+    del ds
 
     # Get stats from file, and from array, and compare
     stats1 = getStatsFromBand(band)

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -529,6 +529,7 @@ def testAllNull():
                        "all nulls").format(k)
                 riostestutils.report(TESTNAME, msg)
                 ok = False
+        del ds
 
     for fn in [infiles.inimg, outfiles.outimg]:
         if os.path.exists(fn):

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -35,7 +35,7 @@ def run():
     """
     riostestutils.reportStart(TESTNAME)
 
-    ok = True
+    allOK = True
     
     # We repeat the basic test for a number of different GDAL datatypes, with different
     # ranges of data. Each element of the following list is a tuple of
@@ -93,13 +93,14 @@ def run():
 
         # Loop over all datatype tuples in the list
         for (fileDtype, scalefactor) in dataTypesForDriver:
-            ok = testForDriverAndType(driverName, creationOptions, fileDtype,
-                scalefactor, rampInfile, ext)
+            ok = testForDriverAndType(driverName, creationOptions,
+                fileDtype, scalefactor, rampInfile, ext)
+            allOK = allOK and ok
     
     if os.path.exists(rampInfile):
         riostestutils.removeRasterFile(rampInfile)
 
-    if ok:
+    if allOK:
         riostestutils.report(TESTNAME, "Passed")
 
     return ok
@@ -187,6 +188,18 @@ def runOneTest(driverName, creationOptions, fileDtype, scalefactor,
             not singlePassMgr.doSinglePassPyramids(symbolicName)):
         ok = False
         msg = "Iteration={}\nSingle-pass requested, but not done for pyramids"
+        riostestutils.report(TESTNAME, msg)
+
+    if (singlePass is True and
+            not singlePassMgr.doSinglePassStatistics(symbolicName)):
+        ok = False
+        msg = "Iteration={}\nSingle-pass requested, but not done for basic stats"
+        riostestutils.report(TESTNAME, msg)
+
+    if (singlePass is True and
+            not singlePassMgr.doSinglePassHistogram(symbolicName)):
+        ok = False
+        msg = "Iteration={}\nSingle-pass requested, but not done for histogram"
         riostestutils.report(TESTNAME, msg)
 
     # Read back the written data as a numpy array

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -149,6 +149,7 @@ def testForDriverAndType(driverName, creationOptions, fileDtype, scalefactor,
 
     # Force single-pass, with thematic output
     if fileDtype not in (hugeIntGDALTypes + floatGDALTypes):
+        print('single-pass/thematic', driverName, fileDtype)
         ok = ok and runOneTest(driverName, creationOptions, fileDtype,
             scalefactor, offset, rampInfile, ext, False, True, True)
 

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -391,7 +391,10 @@ def checkHistogram(band, imgArr, nullVal, iterationName):
     """
     Do simple check(s) on the histogram
     """
-    histValsStr = band.GetMetadataItem("STATISTICS_HISTOBINVALUES")
+    histValsStr = None
+    metadataDict = band.GetMetadata()
+    if "STATISTICS_HISTOBINVALUES" in metadataDict:
+        histValsStr = metadataDict["STATISTICS_HISTOBINVALUES"]
     if histValsStr is not None:
         if histValsStr[-1] == '|':
             # Remove trailing '|'

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -126,8 +126,11 @@ def run():
     return allOK
 
 
-hugeIntGDALTypes = (gdal.GDT_Int32, gdal.GDT_UInt32, gdal.GDT_Int64, gdal.GDT_UInt64)
-floatGDALTypes = (gdal.GDT_Float32, gdal.GDT_Float64)
+hugeIntGDALTypes = (gdal.GDT_Int32, gdal.GDT_UInt32)
+floatGDALTypes = (gdal.GDT_Float32,)
+if hasattr(gdal, 'GDT_Int64'):
+    hugeIntGDALTypes += (gdal.GDT_Int64, gdal.GDT_UInt64)
+    floatGDALTypes += (gdal.GDT_Float64,)
 
 
 def testForDriverAndType(driverName, creationOptions, fileDtype, scalefactor,

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -127,10 +127,9 @@ def run():
 
 
 hugeIntGDALTypes = (gdal.GDT_Int32, gdal.GDT_UInt32)
-floatGDALTypes = (gdal.GDT_Float32,)
+floatGDALTypes = (gdal.GDT_Float32, gdal.GDT_Float64)
 if VersionObj(gdal.__version__) >= VersionObj('3.5.2'):
     hugeIntGDALTypes += (gdal.GDT_Int64, gdal.GDT_UInt64)
-    floatGDALTypes += (gdal.GDT_Float64,)
 
 
 def testForDriverAndType(driverName, creationOptions, fileDtype, scalefactor,

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -99,16 +99,18 @@ def run():
             allOK = allOK and ok
 
     # A simple test of omitting pyramids/stats/histogram
-    ok = runOneTest('KEA', [], gdal.GDT_Byte, 1, 0, rampInfile, 'kea',
+    gtiffOptions = [options for (drvrName, options) in driverTestList
+        if drvrName == "GTiff"][0]
+    ok = runOneTest('GTiff', gtiffOptions, gdal.GDT_Byte, 1, 0, rampInfile, 'tif',
         True, None, False)
     allOK = allOK and ok
     # A test with negative pixel values
-    ok = runOneTest('KEA', [], gdal.GDT_Int16, 300, -20, rampInfile, 'kea',
-        False, None, False)
+    ok = runOneTest('GTiff', gtiffOptions, gdal.GDT_Int16, 300, -20, rampInfile,
+        'tif', False, None, False)
     allOK = allOK and ok
     # A test with no null value
-    ok = runOneTest('KEA', [], gdal.GDT_Byte, 1, 0, rampInfile, 'kea',
-        False, None, False, noNull=True)
+    ok = runOneTest('GTiff', gtiffOptions, gdal.GDT_Byte, 1, 0, rampInfile,
+        'tif', False, None, False, noNull=True)
     allOK = allOK and ok
 
     # Run a test with the output being all null values

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -232,7 +232,6 @@ def runOneTest(driverName, creationOptions, fileDtype, scalefactor, offset,
     ds = gdal.Open(outfiles.outimg)
     band = ds.GetRasterBand(1)
     outarr = band.ReadAsArray()
-    del ds
 
     # Get stats from file, and from array, and compare
     stats1 = getStatsFromBand(band)
@@ -262,6 +261,7 @@ def runOneTest(driverName, creationOptions, fileDtype, scalefactor, offset,
         histOK = checkHistogram(band, outarr, nullVal, iterationName)
         ok = ok and histOK
 
+    del ds
     if os.path.exists(outfiles.outimg):
         riostestutils.removeRasterFile(outfiles.outimg)
     return ok

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -433,7 +433,6 @@ def checkHistogram(band, imgArr, nullVal, iterationName):
                     "for {} values").format(numMismatch))
         else:
             histMax = float(band.GetMetadataItem("STATISTICS_HISTOMAX"))
-            numBins = len(histVals)
             (trueHist, bin_edges) = numpy.histogram(imgArrNonNull,
                 bins=len(histVals), range=(histMin, histMax))
             # For the test cases, it appears that we always get exactly the same

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -419,34 +419,21 @@ def checkHistogram(band, imgArr, nullVal, iterationName):
             ok = False
             msgList.append("Histogram total count error: {} != {}".format(totalCount, trueTotalCount))
 
-        # Test the individual counts, but only for "direct" binning
-        binFunc = band.GetMetadataItem("STATISTICS_HISTOBINFUNCTION")
-        histMin = float(band.GetMetadataItem("STATISTICS_HISTOMIN"))
+        # Test the individual counts
         imgArrNonNull = imgArr[imgArr != nullVal]
-        if binFunc == "direct":
-            trueHist = numpy.bincount(imgArrNonNull)
-            # For athematic direct case, histMin may not be zero
-            trueHist = trueHist[int(histMin):]
-
-            mismatch = (histVals != trueHist)
-            if mismatch.any():
-                ok = False
-                numMismatch = numpy.count_nonzero(mismatch)
-                msgList.append(("Direct-binned histogram mis-match " +
-                    "for {} values").format(numMismatch))
-        else:
-            histMax = float(band.GetMetadataItem("STATISTICS_HISTOMAX"))
-            (trueHist, bin_edges) = numpy.histogram(imgArrNonNull,
-                bins=len(histVals), range=(histMin, histMax))
-            # For the test cases, it appears that we always get exactly the same
-            # linear histogram counts. This feels unexpectedly lucky, but it
-            # makes the following test possible
-            mismatch = (histVals != trueHist)
-            if mismatch.any():
-                ok = False
-                numMismatch = numpy.count_nonzero(mismatch)
-                msgList.append(("Linear-binned histogram mis-match " +
-                    "for {} values").format(numMismatch))
+        histMin = float(band.GetMetadataItem("STATISTICS_HISTOMIN"))
+        histMax = float(band.GetMetadataItem("STATISTICS_HISTOMAX"))
+        (trueHist, bin_edges) = numpy.histogram(imgArrNonNull,
+            bins=len(histVals), range=(histMin, histMax))
+        # For the test cases, it appears that we always get exactly the same
+        # histogram counts. This feels unexpectedly lucky, but it
+        # makes the following test possible
+        mismatch = (histVals != trueHist)
+        if mismatch.any():
+            ok = False
+            numMismatch = numpy.count_nonzero(mismatch)
+            msg = "Histogram mis-match for {} values".format(numMismatch)
+            msgList.append(msg)
     else:
         ok = False
         msgList.append("Histogram not found, so could not be checked")

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -24,7 +24,7 @@ from osgeo.gdal_array import GDALTypeCodeToNumericTypeCode
 
 from rios import calcstats, cuiprogress, VersionObj
 
-from . import riostestutils
+from rios.riostests import riostestutils
 
 TESTNAME = 'TESTSTATS'
 

--- a/rios/structures.py
+++ b/rios/structures.py
@@ -1085,7 +1085,7 @@ class ApplierReturn:
         self.timings = None
         self.otherArgsList = None
         self.workinggrid = None
-        self.singlepassMgr = None
+        self.singlePassMgr = None
 
 
 class WorkerErrorRecord:

--- a/rios/structures.py
+++ b/rios/structures.py
@@ -1084,6 +1084,8 @@ class ApplierReturn:
     def __init__(self):
         self.timings = None
         self.otherArgsList = None
+        self.workinggrid = None
+        self.singlepassMgr = None
 
 
 class WorkerErrorRecord:


### PR DESCRIPTION
Add single-pass calculation for pyramid layers (i.e. overviews), basic statistics, and histograms, on output image files.

### Purpose
In the past, RIOS always used GDAL's own functions to add pyramid layers, statistics and histograms to all output files. These were done after the user processing had completed and the output files were already written. Each of these three components needed a separate call to GDAL, operating on the completed file, and so each required a separate pass through the already-written output rasters.

This pull request adds the ability to do all of these in the same single pass as the processing and writing of each block. This gives a useful saving in time spent on these tasks. For smaller images (< 8,000 x 8,000 pixels), the time spent was never very large anyway, but for much larger images, there was considerable time spent, and so the time saved by doing these with a single pass is also considerable.

The default behaviour is to attempt to use single-pass for all three components, wherever possible, and to fall back on using GDAL when it is not.

Each of the three components is now handled much more independently of the others. This includes new controls methods - ``setOmitBasicStats`` and ``setOmitHistogram``, which match with the previous ``setOmitPyramids``. These provide more granular control than the previous ``setCalcStats`` method, although the latter still works as always.

There are also three new methods to force the use of single-pass or GDAL - ``setSinglePassPyramids``, ``setSinglePassBasicStats``, and ``setSinglePassHistogram``.

The user should not need to make any changes to existing code, and will gain useful speed-ups in writing output files.

### Driver Support
As this code was developed, it became apparent that the KEA driver did not support the direct writing of pyramid layers. Further investigation fixed this problem (https://github.com/OSGeo/gdal/pull/10616), and it should be available in GDAL 3.9.3. To guard against this, the single-pass code tests for driver support (in any driver), and will fall back to at-end GDAL pyramid layers if required.

### Timings
The timings object on the ApplierReturn now includes some new timers. Originally, the ``closing`` timer included the time spent on flushing the final blocks of output, and also all of the time spent in writing pyramids, statistics, and histogram. The final flush is now included in the ``writing`` timer (which is thus more accurate), and the ``closing`` timer has been replaced with separate timers for ``pyramids``, ``basicstats``, and ``histogram``, which accumulate the time spent both calculating and writing the corresponding item.

### Pyramid Layer Aggregation Type
The default aggregation type used for creating pyramid layers with GDAL used to be 'AVERAGE', unless the file had been explicitly set as 'thematic', in which case it was 'NEAREST'. However, it is quite common that outputs are never set to be either thematic or athematic, and so 'AVERAGE' would end up being used more commonly than is appropriate. So, the default is now 'NEAREST' in all cases, which is more than adequate for most purposes.

Furthermore, the use of single-pass pyramids only supports 'NEAREST', so if anything else is explicitly selected, then single-pass is not possible and it will fall back to GDAL.

### Centering of low-resolution pixels
When GDAL's BuildOverviews() function uses 'NEAREST' to subsample the raster, it selects the value from the top-left corner of the low resolution pixel. This is probably a minor bug in GDAL. When single-pass pyramids are used in RIOS, they will use the value at the centre of the low resolution pixel, which removes any sub-pixel shift. This is not a major issue either way, but it seemed good to get it right.

### Test Suite
A lot of tests have been added for all these statistics calculations, checking various different combinations. As a result, the TESTSTATS set of tests now takes noticeably longer, but my paranoia is satisfied. The whole suite is still under 30 seconds, so not too serious.

### Histogram Minimum
The original code would always set the histogram minimum value to be zero for thematic layers, and all 8-bit layers, and use the actual minimum for all other cases. I suspect it was unnecessary, and possibly a bad idea. However, it does appear to have been relied upon in other situations, most notably when using the RAT ``ReadAsArray()`` and ``WriteArray()`` functions to access the Histogram column. Because of this, I have preserved the old behaviour.
