### PR TITLE
Guard when workerBarrier is None

### DIFF
--- a/rios/cmdline/rios_computeworker.py
+++ b/rios/cmdline/rios_computeworker.py
@@ -81,7 +81,8 @@ def riosRemoteComputeWorker(workerID, host, port, authkey):
     blockListByWorker = dataChan.workerInitData.get('blockListByWorker', None)
     blockList = blockListByWorker[workerID]
 
-    if not controls.concurrency.singleBlockComputeWorkers:
+    if (not controls.concurrency.singleBlockComputeWorkers and
+            hasattr(workerBarrier, 'wait')):
         # Wait at the barrier, so nothing proceeds until all workers have had
         # a chance to start
         computeBarrierTimeout = controls.concurrency.computeBarrierTimeout

--- a/rios/structures.py
+++ b/rios/structures.py
@@ -967,7 +967,8 @@ class NetworkDataChannel:
         """
         if hasattr(self, 'server'):
             self.server.stop_event.set()
-            self.workerBarrier.abort()
+            if self.workerBarrier is not None:
+                self.workerBarrier.abort()
             futures.wait([self.serverThread])
             self.threadPool.shutdown()
 


### PR DESCRIPTION
Allowing for the possible case when a network-based compute worker does not need the compute barrier. 