### PR TITLE
Ensure computeMgr shutdown when startWorkers fails

### DIFF
--- a/rios/applier.py
+++ b/rios/applier.py
@@ -1149,6 +1149,7 @@ def apply_multipleCompute(userFunction, infiles, outfiles, otherArgs,
             tmpfileMgr=tmpfileMgr, haveSharedTemp=concurrency.haveSharedTemp,
             exceptionQue=exceptionQue)
     except Exception as e:
+        computeMgr.shutdown()
         if readWorkerMgr is not None:
             readWorkerMgr.shutdown()
         raise e


### PR DESCRIPTION
If computeMgr.startworkers raises exception, then computeMgr should still be shutdown