### PR TITLE
FilenameAssocIterator needs __iter__ method, for py3.13.1

### DIFF
--- a/rios/structures.py
+++ b/rios/structures.py
@@ -372,6 +372,9 @@ class FilenameAssocIterator(object):
         else:
             raise StopIteration()
 
+    def __iter__(self):
+        return self
+
 
 class BlockAssociations:
     """


### PR DESCRIPTION
Python changes in 3.13.1 now requires strict adherence to the iter protocol, although it used to be looser. Apparently this was not intended, see [here](https://github.com/python/cpython/issues/128161) for some discussion. However, we should probably adhere to the strict definitions anyway. 

I confess I don't fully understand the iterable protocol, but this change now passes all tests with python 3.13.1. 