### PR TITLE
fix for issue where np.nan was not ignored for stats

### DIFF
--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -639,6 +639,8 @@ class SinglePassAccumulator:
         """
         if self.nullval is None:
             values = arr.flatten()
+        elif numpy.isnan(self.nullval):
+            values = arr[~numpy.isnan(arr)]
         else:
             values = arr[arr != self.nullval]
         if len(values) > 0:


### PR DESCRIPTION
addresses issue #125 by adding a specific check for numpy.nan (not caught by the standard python equality test)