### PR TITLE
Sensible default behaviour for computeWorkersRead parameter

### DIFF
--- a/rios/applier.py
+++ b/rios/applier.py
@@ -1128,6 +1128,9 @@ def apply_multipleCompute(userFunction, infiles, outfiles, otherArgs,
 
     inBlockBuffer = None
     readWorkerMgr = None
+    if concurrency.computeWorkersRead is None:
+        # Take the default from the computeMgr class
+        concurrency.computeWorkersRead = computeMgr.computeWorkersRead_default
     if not concurrency.computeWorkersRead:
         inBlockBuffer = BlockBuffer(infiles, concurrency.numReadWorkers,
             concurrency.readBufferInsertTimeout,
@@ -1144,7 +1147,6 @@ def apply_multipleCompute(userFunction, infiles, outfiles, otherArgs,
             otherArgs=otherArgs, controls=controls, blockList=blockList,
             inBlockBuffer=inBlockBuffer, outBlockBuffer=outBlockBuffer,
             workinggrid=workinggrid, allInfo=allInfo,
-            computeWorkersRead=concurrency.computeWorkersRead,
             singleBlockComputeWorkers=concurrency.singleBlockComputeWorkers,
             tmpfileMgr=tmpfileMgr, haveSharedTemp=concurrency.haveSharedTemp,
             exceptionQue=exceptionQue)

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -56,14 +56,14 @@ class ComputeWorkerManager(ABC):
     outObjList = None
     outqueue = None
     jobName = None
+    computeWorkersRead_default = None
 
     @abstractmethod
     def startWorkers(self, numWorkers=None, userFunction=None,
             infiles=None, outfiles=None, otherArgs=None, controls=None,
             blockList=None, inBlockBuffer=None, outBlockBuffer=None,
-            workinggrid=None, allInfo=None, computeWorkersRead=False,
-            singleBlockComputeWorkers=False, tmpfileMgr=None,
-            haveSharedTemp=True, exceptionQue=None):
+            workinggrid=None, allInfo=None, singleBlockComputeWorkers=False,
+            tmpfileMgr=None, haveSharedTemp=True, exceptionQue=None):
         """
         Start the specified compute workers
         """
@@ -162,6 +162,7 @@ class ThreadsComputeWorkerMgr(ComputeWorkerManager):
     Manage compute workers using threads within the current process.
     """
     computeWorkerKind = CW_THREADS
+    computeWorkersRead_default = False
 
     def __init__(self):
         self.threadPool = None
@@ -172,9 +173,8 @@ class ThreadsComputeWorkerMgr(ComputeWorkerManager):
     def startWorkers(self, numWorkers=None, userFunction=None,
             infiles=None, outfiles=None, otherArgs=None, controls=None,
             blockList=None, inBlockBuffer=None, outBlockBuffer=None,
-            workinggrid=None, allInfo=None, computeWorkersRead=False,
-            singleBlockComputeWorkers=False, tmpfileMgr=None,
-            haveSharedTemp=True, exceptionQue=None):
+            workinggrid=None, allInfo=None, singleBlockComputeWorkers=False,
+            tmpfileMgr=None, haveSharedTemp=True, exceptionQue=None):
         """
         Start <numWorkers> threads to process blocks of data
         """
@@ -254,13 +254,13 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
     """
     computeWorkerKind = CW_ECS
     defaultWaitClusterInstanceCountTimeout = 300
+    computeWorkersRead_default = True
 
     def startWorkers(self, numWorkers=None, userFunction=None,
             infiles=None, outfiles=None, otherArgs=None, controls=None,
             blockList=None, inBlockBuffer=None, outBlockBuffer=None,
-            workinggrid=None, allInfo=None, computeWorkersRead=False,
-            singleBlockComputeWorkers=False, tmpfileMgr=None,
-            haveSharedTemp=True, exceptionQue=None):
+            workinggrid=None, allInfo=None, singleBlockComputeWorkers=False,
+            tmpfileMgr=None, haveSharedTemp=True, exceptionQue=None):
         """
         Start <numWorkers> ECS tasks to process blocks of data
         """
@@ -664,13 +664,13 @@ class AWSBatchComputeWorkerMgr(ComputeWorkerManager):
     Manage compute workers using AWS Batch.
     """
     computeWorkerKind = CW_AWSBATCH
+    computeWorkersRead_default = True
 
     def startWorkers(self, numWorkers=None, userFunction=None,
             infiles=None, outfiles=None, otherArgs=None, controls=None,
             blockList=None, inBlockBuffer=None, outBlockBuffer=None,
-            workinggrid=None, allInfo=None, computeWorkersRead=False,
-            singleBlockComputeWorkers=False, tmpfileMgr=None,
-            haveSharedTemp=True, exceptionQue=None):
+            workinggrid=None, allInfo=None, singleBlockComputeWorkers=False,
+            tmpfileMgr=None, haveSharedTemp=True, exceptionQue=None):
         """
         Start <numWorkers> AWS Batch jobs to process blocks of data
         """
@@ -763,13 +763,13 @@ class ClassicBatchComputeWorkerMgr(ComputeWorkerManager):
 
     """
     computeWorkerKind = None
+    computeWorkersRead_default = True
 
     def startWorkers(self, numWorkers=None, userFunction=None,
             infiles=None, outfiles=None, otherArgs=None, controls=None,
             blockList=None, inBlockBuffer=None, outBlockBuffer=None,
-            workinggrid=None, allInfo=None, computeWorkersRead=False,
-            singleBlockComputeWorkers=False, tmpfileMgr=None,
-            haveSharedTemp=True, exceptionQue=None):
+            workinggrid=None, allInfo=None, singleBlockComputeWorkers=False,
+            tmpfileMgr=None, haveSharedTemp=True, exceptionQue=None):
         """
         Start <numWorkers> PBS or SLURM jobs to process blocks of data
         """
@@ -1064,13 +1064,13 @@ class SubprocComputeWorkerManager(ComputeWorkerManager):
 
     """
     computeWorkerKind = CW_SUBPROC
+    computeWorkersRead_default = False
 
     def startWorkers(self, numWorkers=None, userFunction=None,
             infiles=None, outfiles=None, otherArgs=None, controls=None,
             blockList=None, inBlockBuffer=None, outBlockBuffer=None,
-            workinggrid=None, allInfo=None, computeWorkersRead=False,
-            singleBlockComputeWorkers=False, tmpfileMgr=None,
-            haveSharedTemp=True, exceptionQue=None):
+            workinggrid=None, allInfo=None, singleBlockComputeWorkers=False,
+            tmpfileMgr=None, haveSharedTemp=True, exceptionQue=None):
         """
         Start the specified compute workers
         """

--- a/rios/structures.py
+++ b/rios/structures.py
@@ -127,20 +127,22 @@ class ConcurrencyStyle:
             The number of distinct compute workers. If zero, then
             computation happens within the main processing loop.
         computeWorkersRead: bool
+            The default is None, which means that a sensible True/False
+            choice will be made by the selected computeWorkerKind.
+
             If True, then each compute worker does its own reading,
             possibly with its own pool of read worker threads
             (<numReadWorkers> threads for each compute worker). This
-            is likely to be a good option when used with the batch
-            queue oriented compute workers, with workers running on
-            separate machines.
+            is likely to be a good option with any computeWorkerKind
+            which involves compute workers running on separate machines.
 
             If False, then all reading is done by the main RIOS process
             (possibly using one or more read workers) and data is sent
-            directly to each compute worker. False is required for CW_THREADS
-            compute workers, but may also be useful in cases when batch
-            queue nodes are on an internal network, but input files are
-            not accessible to the batch nodes, and must be read by a process
-            on the gateway machine.
+            directly to each compute worker. False (or None) is required
+            for CW_THREADS compute workers, but may also be useful in cases
+            when compute workers are on separate machines on an internal
+            network, but input files are not accessible to those machines,
+            and must be read by the main RIOS process.
         singleBlockComputeWorkers: bool
             This applies only to the batch queue paradigms. In some
             batch configurations, it is advantageous to run many small,
@@ -199,7 +201,7 @@ class ConcurrencyStyle:
     def __init__(self, numReadWorkers=0, numComputeWorkers=0,
                  computeWorkerKind=CW_NONE,
                  computeWorkerExtraParams=None,
-                 computeWorkersRead=False,
+                 computeWorkersRead=None,
                  singleBlockComputeWorkers=False,
                  haveSharedTemp=True,
                  readBufferInsertTimeout=10,
@@ -251,7 +253,7 @@ class ConcurrencyStyle:
                    "computeWorkerKind == {}".format(computeWorkerKind))
             raise ValueError(msg)
 
-        if ((numComputeWorkers > 0) and (not computeWorkersRead) and
+        if ((numComputeWorkers > 0) and (computeWorkersRead is False) and
                 (numReadWorkers == 0)):
             msg = ("Multiple non-reading compute workers with " +
                    "zero read workers is not a sensible choice. Best "


### PR DESCRIPTION
The default value for computeWorkersRead (in the ConcurrencyStyle constructor) is now None, which means that the behaviour will be selected by the chosen computeWorkerMgr class to be its own sensible default. The computeWorkersRead argument can still be explicitly set to True or False to over-ride the default, but this change means it will only rarely be necessary to specify it.