### PR TITLE
Added controls.setCallBeforeClose()

### DIFF
--- a/rios/applier.py
+++ b/rios/applier.py
@@ -108,6 +108,7 @@ class ApplierControls(object):
         * **approxStats**       Allow approx stats (much faster)
         * **layerselection**  List of selected layer numbers for input
         * **jobName**         String name for this job, for cosmetic use only
+        * **callBeforeClose**   Function and args to call before closing output file
     
     Options relating to vector input files
         * **burnvalue**       Value to burn into raster from vector
@@ -154,6 +155,7 @@ class ApplierControls(object):
         self.approxStats = False
         self.layerselection = None
         self.jobName = None
+        self.callBeforeClose = None
 
         # Vector fields
         self.burnvalue = 1
@@ -856,6 +858,19 @@ class ApplierControls(object):
 
         """
         self.setOptionForImagename('approxStats', imagename, approxStats)
+
+    def setCallBeforeClose(self, beforeCloseFunc, beforeCloseArgs, imagename=None):
+        """
+        Set a function and its arguments, to be called on an output image,
+        just before it is closed.
+
+        The function has the following call sequence::
+
+            beforeCloseFunc(outputDataset, *beforeCloseArgs)
+
+        """
+        self.setOptionForImagename('callBeforeClose', imagename,
+            (beforeCloseFunc, beforeCloseArgs))
 
     def emulateOldJobManager(self):
         """

--- a/rios/imagewriter.py
+++ b/rios/imagewriter.py
@@ -203,6 +203,7 @@ def closeOutfiles(gdalOutObjCache, outfiles, controls, singlePassMgr, timings):
         overviewAggType = getOpt('overviewAggType', symbolicName)
         approxStats = getOpt('approxStats', symbolicName)
         autoColorTableType = getOpt('autoColorTableType', symbolicName)
+        callBeforeClose = getOpt('callBeforeClose', symbolicName)
         progress = getOpt('progress', symbolicName)
         if progress is None:
             from .cuiprogress import SilentProgress
@@ -239,6 +240,11 @@ def closeOutfiles(gdalOutObjCache, outfiles, controls, singlePassMgr, timings):
         elif not omitHistogram:
             with timings.interval('histogram'):
                 calcstats.addHistogramsGDAL(ds, minMaxList, approxStats)
+
+        if callBeforeClose is not None and len(callBeforeClose) == 2:
+            (beforeCloseFunc, beforeCloseArgs) = callBeforeClose
+            with timings.interval('beforeclose'):
+                beforeCloseFunc(ds, *beforeCloseArgs)
 
         # This is doing everything I can to ensure the file gets fully closed
         # at this point.

--- a/rios/riostests/riostestutils.py
+++ b/rios/riostests/riostestutils.py
@@ -278,6 +278,11 @@ def testAll():
     if not ok:
         failureCount += 1
 
+    from . import testbeforeclose
+    ok = testbeforeclose.run()
+    if not ok:
+        failureCount += 1
+
     from . import testrat
     ok = testrat.run()
     if not ok:

--- a/rios/riostests/testbeforeclose.py
+++ b/rios/riostests/testbeforeclose.py
@@ -1,0 +1,67 @@
+"""
+Test the beforeCloseFunc callback.
+
+This is a function which is called just before the output file is closed,
+and is passed the still-open Dataset.
+
+"""
+from osgeo import gdal
+from rios import applier
+
+from rios.riostests import riostestutils
+
+TESTNAME = "TESTBEFORECLOSE"
+
+
+def run():
+    """
+    Run the test
+    """
+    riostestutils.reportStart(TESTNAME)
+    
+    ramp = 'ramp.img'
+    riostestutils.genRampImageFile(ramp)
+    outfile = 'out.img'
+
+    infiles = applier.FilenameAssociations()
+    outfiles = applier.FilenameAssociations()
+    controls = applier.ApplierControls()
+    infiles.img = ramp
+    outfiles.outimg = outfile
+    nameValPair = ('dummyName', 'dummyVal')
+    controls.setCallBeforeClose(callBeforeCloseFunc, nameValPair,
+        imagename='outimg')
+    
+    applier.apply(userFunc, infiles, outfiles, controls=controls)
+
+    # Check that the function ran OK
+    ds = gdal.Open(outfile)
+    val = ds.GetMetadataItem(nameValPair[0]) + 'z'
+    ok = (val == nameValPair[1])
+    if not ok:
+        msg = "Failed in call to 'beforeClose' function"
+        riostestutils.report(TESTNAME, msg)
+    
+    # Clean up
+    for filename in [ramp, outfile]:
+        riostestutils.removeRasterFile(filename)
+
+    if ok:
+        riostestutils.report(TESTNAME, "Passed")
+    
+    return ok
+
+
+def userFunc(info, inputs, outputs):
+    outputs.outimg = inputs.img
+
+
+def callBeforeCloseFunc(ds, name, val):
+    """
+    Called before closing. Sets an arbitrary metadata item on the ds.
+    """
+    ds.SetMetadataItem(name, val)
+
+
+if __name__ == "__main__":
+    run()

--- a/rios/structures.py
+++ b/rios/structures.py
@@ -838,8 +838,8 @@ class Timers:
         ]
         fieldOrder = ['reading', 'startcomputeworkers', 'userfunction',
             'writing', 'pyramids', 'basicstats', 'stats+histogram', 'histogram',
-            'insert_readbuffer', 'pop_readbuffer', 'insert_computebuffer',
-            'pop_computebuffer']
+            'beforeclose', 'insert_readbuffer', 'pop_readbuffer',
+            'insert_computebuffer', 'pop_computebuffer']
         for name in fieldOrder:
             if name in d:
                 line = "{:20s}    {:8.1f}".format(name, d[name]['tot'])


### PR DESCRIPTION
This PR adds an optional function which will be called just before closing output file(s). This can be used for special behaviour on the still-open Dataset, should this be required. The function (and its arguments) are set on the ApplierControls object.