### PR TITLE
Ensure pickleable Timers using the correct mechanisms

### DIFF
--- a/rios/cmdline/rios_computeworker.py
+++ b/rios/cmdline/rios_computeworker.py
@@ -7,7 +7,7 @@ import argparse
 from osgeo import gdal
 
 from rios import applier
-from rios.structures import NetworkDataChannel, Timers, WorkerErrorRecord
+from rios.structures import NetworkDataChannel, WorkerErrorRecord
 
 
 # Compute workers in separate processes should always use GDAL exceptions,
@@ -93,9 +93,7 @@ def riosRemoteComputeWorker(workerID, host, port, authkey):
             otherArgs, controls, allInfo, workinggrid, blockList,
             outBlockBuffer, inBlockBuffer, workerID, forceExit)
 
-        # Make a pickleable version of the timings
-        timings = Timers(pairs=rtn.timings.pairs, withlock=False)
-        dataChan.outqueue.put(timings)
+        dataChan.outqueue.put(rtn.timings)
         if otherArgs is not None:
             dataChan.outqueue.put(otherArgs)
     except Exception as e:

--- a/rios/structures.py
+++ b/rios/structures.py
@@ -747,18 +747,12 @@ class Timers:
     time when this operation was carried out.
 
     The object is thread-safe, so multiple threads can accumulate to
-    the same names.
+    the same names. The object is also pickle-able.
 
     """
-    def __init__(self, pairs=None, withlock=True):
-        if pairs is None:
-            self.pairs = {}
-        else:
-            self.pairs = pairs
-        if withlock:
-            self.lock = threading.Lock()
-        else:
-            self.lock = None
+    def __init__(self):
+        self.pairs = {}
+        self.lock = threading.Lock()
 
     @contextlib.contextmanager
     def interval(self, intervalName):
@@ -859,6 +853,22 @@ class Timers:
                     reportLines.append(line)
         reportStr = '\n'.join(reportLines)
         return reportStr
+
+    def __getstate__(self):
+        """
+        Ensure pickleability by omitting the lock attribute
+        """
+        d = {}
+        d.update(self.__dict__)
+        d.pop('lock')
+        return d
+
+    def __setstate__(self, state):
+        """
+        For unpickling, add a new lock attribute
+        """
+        self.__dict__.update(state)
+        self.lock = threading.Lock()
 
 
 class NetworkDataChannel:


### PR DESCRIPTION
A Timers object needs to be pickleable in order to be passed back from a remote compute worker. The current implementation uses a dirty hack to achieve this. I now understand the use of `__getstate__` & `__setstate__` to do this properly, so this pull requests converts to this standard mechanism.