### PR TITLE
Improved error handling in CW_ECS cases

### DIFF
--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -507,8 +507,9 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             # Grab all the container exit codes/reasons. Note that we
             # know we have only one container per task.
             ctrDescrList = [t['containers'][0] for t in descr['tasks']]
-            ecList = [(c['exitCode'], c['reason']) for c in ctrDescrList]
-            exitCodeList.extend(ecList)
+            for c in ctrDescrList:
+                if 'exitCode' in c and 'reason' in c:
+                    exitCodeList.append((c['exitCode'], c['reason']))
             i = j
 
         for f in failures:

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -504,8 +504,9 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             descr = self.ecsClient.describe_tasks(cluster=self.clusterName,
                 tasks=self.taskArnList[i:j])
             failures.extend(descr['failures'])
-            # Grab all the container exit codes/reasons
-            ctrDescrList = [t['containers'] for t in descr['tasks']]
+            # Grab all the container exit codes/reasons. Note that we
+            # know we have only one container per task.
+            ctrDescrList = [t['containers'][0] for t in descr['tasks']]
             ecList = [(c['exitCode'], c['reason']) for c in ctrDescrList]
             exitCodeList.extend(ecList)
             i = j

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -346,6 +346,7 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         """
         self.forceExit.set()
         self.makeOutObjList()
+        self.waitClusterTasksFinished()
         self.checkTaskErrors()
         if hasattr(self, 'dataChan'):
             self.dataChan.shutdown()
@@ -364,7 +365,6 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             self.ec2client.terminate_instances(InstanceIds=instIdList)
             self.waitClusterInstanceCount(self.clusterName, 0)
         if self.createdCluster:
-            self.waitClusterTasksFinished()
             self.ecsClient.delete_cluster(cluster=self.clusterName)
 
     @staticmethod

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -514,11 +514,9 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         for f in failures:
             print("Failure in ECS task:", f['reason'], file=sys.stderr)
             print("    ", f['details'], file=sys.stderr)
-            print(file=sys.stderr)
         for (exitCode, reason) in exitCodeList:
             if exitCode != 0:
                 print("Error in ECS task container:", reason, file=sys.stderr)
-                print(file=sys.stderr)
 
     @staticmethod
     def makeExtraParams_Fargate(jobName=None, containerImage=None,


### PR DESCRIPTION
ECSComputeWorkerMgr now does comprehensive checks of ECS task status before shutting down. 
The suggested config for Fargate now creates its own temporary cluster, removing the need to pass in (and create) a clusterName.