### PR TITLE
Improve CW_ECS error handling and add CloudWatch logging

### DIFF
--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -524,8 +524,8 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             print("    ", f.get('details'), file=sys.stderr)
         for (exitCode, reason) in exitCodeList:
             if exitCode != 0:
-                print("Exit code {} from ECS task container:", exitCode,
-                    reason, file=sys.stderr)
+                print("Exit code {} from ECS task container: {}".format(
+                    exitCode, reason), file=sys.stderr)
 
     @staticmethod
     def makeExtraParams_Fargate(jobName=None, containerImage=None,

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -524,7 +524,8 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             print("    ", f.get('details'), file=sys.stderr)
         for (exitCode, reason) in exitCodeList:
             if exitCode != 0:
-                print("Error in ECS task container:", reason, file=sys.stderr)
+                print("Error ({}) in ECS task container:", exitCode,
+                    reason, file=sys.stderr)
 
     @staticmethod
     def makeExtraParams_Fargate(jobName=None, containerImage=None,

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -524,7 +524,7 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             print("    ", f.get('details'), file=sys.stderr)
         for (exitCode, reason) in exitCodeList:
             if exitCode != 0:
-                print("Error ({}) in ECS task container:", exitCode,
+                print("Exit code {} from ECS task container:", exitCode,
                     reason, file=sys.stderr)
 
     @staticmethod

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -531,7 +531,7 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
     def makeExtraParams_Fargate(jobName=None, containerImage=None,
             taskRoleArn=None, executionRoleArn=None, subnets=None,
             securityGroups=None, cpu='0.5 vCPU', memory='1GB',
-            cpuArchitecture=None):
+            cpuArchitecture=None, cloudwatchLogGroup=None):
         """
         Helper function to construct a minimal computeWorkerExtraParams
         dictionary suitable for using ECS with Fargate launchType, given
@@ -573,6 +573,11 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         cpuArchitecture : str
             If given, selects the CPU architecture of the hosts to run worker on.
             Can be 'ARM64', defaults to 'X86_64'.
+        cloudwatchLogGroup : str or None
+            Optional. Name of CloudWatch log group. If not None, each worker
+            sends a log stream of its stdout & stderr to this log group. The
+            group should already exist. If None, no CloudWatch logging is done.
+            Intended for tracking obscure problems, rather than to use permanently.
 
         Only certain combinations of cpu and memory are allowed, as these are used
         by Fargate to select a suitable VM instance type. See ESC.Client.run_task()
@@ -589,6 +594,19 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         containerDefs = [{'name': containerName,
                           'image': containerImage,
                           'entryPoint': ['/usr/bin/env', 'rios_computeworker']}]
+        if cloudwatchLogGroup is not None:
+            # We are using the default session, so ask it what region
+            session = boto3._get_default_session()
+            regionName = session.region_name
+            # Set up the cloudwatch log configuration
+            containerDefs[0]['logConfiguration'] = {
+                'logDriver': 'awslogs',
+                'options': {
+                    'awslogs-group': cloudwatchLogGroup,
+                    'awslogs-stream-prefix': f'/RIOS_{jobIDstr}',
+                    'awslogs-region': regionName
+                }
+            }
 
         networkConf = {
             'awsvpcConfiguration': {
@@ -635,7 +653,7 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             ami=None, instanceType=None, containerImage=None,
             taskRoleArn=None, executionRoleArn=None,
             subnet=None, securityGroups=None, instanceProfileArn=None,
-            memoryReservation=1024):
+            memoryReservation=1024, cloudwatchLogGroup=None):
         """
         Helper function to construct a basic computeWorkerExtraParams
         dictionary suitable for using ECS with a private per-job cluster,
@@ -685,7 +703,14 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             instances to be part of an ECS cluster.
         memoryReservation : int
             Optional. Memory (in MiB) reserved for the containers in each
-            compute worker.
+            compute worker. This should be small enough to fit well inside the
+            memory of the VM on which it is running. Often best to leave this
+            as default until out-of-memory errors occur, then increase.
+        cloudwatchLogGroup : str or None
+            Optional. Name of CloudWatch log group. If not None, each worker
+            sends a log stream of its stdout & stderr to this log group. The
+            group should already exist. If None, no CloudWatch logging is done.
+            Intended for tracking obscure problems, rather than to use permanently.
 
         """
         jobIDstr = ECSComputeWorkerMgr.makeJobIDstr(jobName)
@@ -713,6 +738,19 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
                           'image': containerImage,
                           'memoryReservation': memoryReservation,
                           'entryPoint': ['/usr/bin/env', 'rios_computeworker']}]
+        if cloudwatchLogGroup is not None:
+            # We are using the default session, so ask it what region
+            session = boto3._get_default_session()
+            regionName = session.region_name
+            # Set up the cloudwatch log configuration
+            containerDefs[0]['logConfiguration'] = {
+                'logDriver': 'awslogs',
+                'options': {
+                    'awslogs-group': cloudwatchLogGroup,
+                    'awslogs-stream-prefix': f'/RIOS_{jobIDstr}',
+                    'awslogs-region': regionName
+                }
+            }
 
         networkConf = {
             'awsvpcConfiguration': {

--- a/rios/riostests/riostestutils.py
+++ b/rios/riostests/riostestutils.py
@@ -50,7 +50,7 @@ platformName = platform.system()
 
 def checkBindSocket():
     """
-    Check whether we can bind a socket. Needed because Github's server's
+    Check whether we can bind a socket. Needed because Github's servers
     have stopped allowing this, so we need to disable tests which use
     the NetworkDataChannel structure.
 


### PR DESCRIPTION
More robust handling of ECS task exit codes and reason strings. Added option for logging ECS worker stdout & stderr into an AWS CloudWatch log group.