### PR TITLE
Full support for gdal.GDT_Int8 outputs

### DIFF
--- a/rios/imagewriter.py
+++ b/rios/imagewriter.py
@@ -159,6 +159,9 @@ def openOutfile(symbolicName, filename, controls, arr, workinggrid):
 
     numBands = arr.shape[0]
     gdalDatatype = gdal_array.NumericTypeCodeToGDALTypeCode(arr.dtype)
+    if gdalDatatype is None:
+        msg = f"Array type {arr.dtype} has no corresponding GDAL data type"
+        raise rioserrors.ImageOpenError(msg)
     (nrows, ncols) = workinggrid.getDimensions()
     geotransform = workinggrid.makeGeoTransform()
     projWKT = workinggrid.projection

--- a/rios/riostests/riostestutils.py
+++ b/rios/riostests/riostestutils.py
@@ -295,6 +295,11 @@ def testAll():
     if not ok:
         failureCount += 1
 
+    from . import testsigned8bit
+    ok = testsigned8bit.run()
+    if not ok:
+        failureCount += 1
+
     from . import testpyramids
     ok = testpyramids.run()
     if not ok:

--- a/rios/riostests/testsigned8bit.py
+++ b/rios/riostests/testsigned8bit.py
@@ -43,27 +43,26 @@ def run():
     allOK = True
 
     if not hasattr(gdal, 'GDT_Int8'):
-        msg = "GDT_Int8 support only available with GDAL >= 3.7"
+        msg = "Skipped. GDT_Int8 support only available with GDAL >= 3.7"
         riostestutils.report(TESTNAME, msg)
-        allOK = False
+    else:
+        (nRows, nCols) = (1, 256)
+        if allOK:
+            inimg = "int8.tif"
+            outimg = "int8_2.tif"
+            ok = readAndWrite(inimg, outimg, nRows, nCols)
+            allOK = ok
 
-    (nRows, nCols) = (1, 256)
-    if allOK:
-        inimg = "int8.tif"
-        outimg = "int8_2.tif"
-        ok = readAndWrite(inimg, outimg, nRows, nCols)
-        allOK = ok
+        if allOK:
+            ok = checkHistogram(outimg, nCols)
+            allOK = ok
 
-    if allOK:
-        ok = checkHistogram(outimg, nCols)
-        allOK = ok
+        if allOK:
+            riostestutils.report(TESTNAME, "Passed")
 
-    if allOK:
-        riostestutils.report(TESTNAME, "Passed")
-
-    for fn in [inimg, outimg]:
-        if os.path.exists(fn):
-            riostestutils.removeRasterFile(fn)
+        for fn in [inimg, outimg]:
+            if os.path.exists(fn):
+                riostestutils.removeRasterFile(fn)
 
     return allOK
 

--- a/rios/riostests/testsigned8bit.py
+++ b/rios/riostests/testsigned8bit.py
@@ -107,6 +107,18 @@ def readAndWrite(inimg, outimg, nRows, nCols):
         riostestutils.report(TESTNAME, msg)
         ok = False
 
+    ds = gdal.Open(outimg)
+    band = ds.GetRasterBand(1)
+    if band.DataType != gdal.GDT_Int8:
+        msg = f"Output file should be GDT_Int8, actually {band.DataType}"
+        riostestutils.report(TESTNAME, msg)
+        ok = False
+    arr = band.ReadAsArray()
+    if arr.dtype != numpy.int8:
+        msg = f"Output image data should be int8, actually {arr.dtype}"
+        riostestutils.report(TESTNAME, msg)
+        ok = False
+
     return ok
 
 

--- a/rios/riostests/testsigned8bit.py
+++ b/rios/riostests/testsigned8bit.py
@@ -25,9 +25,8 @@ import traceback
 
 import numpy
 from osgeo import gdal
-from osgeo.gdal_array import GDALTypeCodeToNumericTypeCode
 
-from rios import applier, VersionObj
+from rios import applier
 
 from rios.riostests import riostestutils
 

--- a/rios/riostests/testsigned8bit.py
+++ b/rios/riostests/testsigned8bit.py
@@ -4,6 +4,7 @@ in version 3.7, and only later supported properly by RIOS.
 
 This does not test the earlier GDAL implementation using 'PIXELTYPE=SIGNEDBYTE',
 as this is not supported by RIOS.
+
 """
 # This file is part of RIOS - Raster I/O Simplification
 # Copyright (C) 2012  Sam Gillingham, Neil Flood

--- a/rios/riostests/testsigned8bit.py
+++ b/rios/riostests/testsigned8bit.py
@@ -47,11 +47,10 @@ def run():
         riostestutils.report(TESTNAME, msg)
     else:
         (nRows, nCols) = (1, 256)
-        if allOK:
-            inimg = "int8.tif"
-            outimg = "int8_2.tif"
-            ok = readAndWrite(inimg, outimg, nRows, nCols)
-            allOK = ok
+        inimg = "int8.tif"
+        outimg = "int8_2.tif"
+        ok = readAndWrite(inimg, outimg, nRows, nCols)
+        allOK = ok
 
         if allOK:
             ok = checkHistogram(outimg, nCols)

--- a/rios/riostests/testsigned8bit.py
+++ b/rios/riostests/testsigned8bit.py
@@ -113,9 +113,13 @@ def readAndWrite(inimg, outimg, nRows, nCols):
         msg = f"Output file should be GDT_Int8, actually {band.DataType}"
         riostestutils.report(TESTNAME, msg)
         ok = False
-    arr = band.ReadAsArray()
-    if arr.dtype != numpy.int8:
-        msg = f"Output image data should be int8, actually {arr.dtype}"
+    newArr = band.ReadAsArray()
+    if newArr.dtype != numpy.int8:
+        msg = f"Output image data should be int8, actually {newArr.dtype}"
+        riostestutils.report(TESTNAME, msg)
+        ok = False
+    if (newArr != arr).any():
+        msg = "Output GDT_Int8 data not correctly returned"
         riostestutils.report(TESTNAME, msg)
         ok = False
 

--- a/rios/riostests/testsigned8bit.py
+++ b/rios/riostests/testsigned8bit.py
@@ -1,0 +1,151 @@
+"""
+Test the use of signed 8-bit rasters. The Int8 type was added to GDAL
+in version 3.7, and only later supported properly by RIOS.
+
+This does not test the earlier GDAL implementation using 'PIXELTYPE=SIGNEDBYTE',
+as this is not supported by RIOS.
+"""
+# This file is part of RIOS - Raster I/O Simplification
+# Copyright (C) 2012  Sam Gillingham, Neil Flood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+import traceback
+
+import numpy
+from osgeo import gdal
+from osgeo.gdal_array import GDALTypeCodeToNumericTypeCode
+
+from rios import applier, VersionObj
+
+from rios.riostests import riostestutils
+
+
+TESTNAME = 'TESTSIGNED8BIT'
+
+
+def run():
+    """
+    Run a test of statistics calculation
+    """
+    riostestutils.reportStart(TESTNAME)
+
+    allOK = True
+
+    if not hasattr(gdal, 'GDT_Int8'):
+        msg = "GDT_Int8 support only available with GDAL >= 3.7"
+        riostestutils.report(TESTNAME, msg)
+        allOK = False
+
+    (nRows, nCols) = (1, 256)
+    if allOK:
+        inimg = "int8.tif"
+        outimg = "int8_2.tif"
+        ok = readAndWrite(inimg, outimg, nRows, nCols)
+        allOK = ok
+
+    if allOK:
+        ok = checkHistogram(outimg, nCols)
+        allOK = ok
+
+    if allOK:
+        riostestutils.report(TESTNAME, "Passed")
+
+    for fn in [inimg, outimg]:
+        if os.path.exists(fn):
+            riostestutils.removeRasterFile(fn)
+
+    return allOK
+
+
+def readAndWrite(inimg, outimg, nRows, nCols):
+    """
+    Create a small signed 8-bit raster, and use RIOS to read it and write it
+    out again, testing both the reading and writing
+    """
+    infiles = applier.FilenameAssociations()
+    outfiles = applier.FilenameAssociations()
+    controls = applier.ApplierControls()
+    otherargs = applier.OtherInputs()
+
+    infiles.inimg = inimg
+    outfiles.outimg = outimg
+    controls.setOutputDriverName("GTiff")
+    controls.setStatsIgnore(None)
+
+    creationOptions = ['COMPRESS=DEFLATE', 'TILED=YES']
+    gdt = gdal.GDT_Int8
+    ds = riostestutils.createTestFile(infiles.inimg,
+        numRows=nRows, numCols=nCols, driverName='GTiff',
+        dtype=gdt, creationOptions=creationOptions)
+
+    arr = numpy.arange(-128, 128, dtype=numpy.int8).reshape((nRows, nCols))
+    ds.GetRasterBand(1).WriteArray(arr)
+    del ds
+
+    ok = True
+    try:
+        applier.apply(copy, infiles, outfiles, otherargs,
+            controls=controls)
+        if otherargs.inDtype != numpy.int8:
+            msg = "Input dtype is {}, should be int8".format(otherargs.inDtype)
+            riostestutils.report(TESTNAME, msg)
+            ok = False
+    except Exception as e:
+        tbStr = ''.join(traceback.format_exception(e))
+        msg = f"Exception raised:\n{tbStr}"
+        riostestutils.report(TESTNAME, msg)
+        ok = False
+
+    return ok
+
+
+def checkHistogram(outimg, ncols):
+    """
+    Check that the histogram on the output file is correct
+    """
+    # We got through without an exception, now check that the values are correct
+    ds = gdal.Open(outimg)
+    band = ds.GetRasterBand(1)
+    md = band.GetMetadata()
+    ok = True
+    if int(md['STATISTICS_HISTOMIN']) != -128:
+        msg = "HISTOMIN incorrect {} != {}".format(md['STATISTICS_HISTOMIN'], -128)
+        riostestutils.report(TESTNAME, msg)
+        ok = False
+    if int(md['STATISTICS_HISTOMAX']) != 127:
+        msg = "HISTOMAX incorrect {} != {}".format(md['STATISTICS_HISTOMAX'], 127)
+        riostestutils.report(TESTNAME, msg)
+        ok = False
+    trueHist = numpy.ones(ncols)
+    histStr = md['STATISTICS_HISTOBINVALUES']
+    hist = numpy.array([int(i) for i in histStr.split('|')[:-1]])
+    if (hist != trueHist).any():
+        msg = "HISTOBINVALUES incorrect {} != {}".format(hist, trueHist)
+        riostestutils.report(TESTNAME, msg)
+        ok = False
+
+    return ok
+
+
+def copy(info, inputs, outputs, otherargs):
+    """
+    Called from RIOS. Write input to output
+    """
+    otherargs.inDtype = inputs.inimg.dtype
+    outputs.outimg = inputs.inimg
+
+
+if __name__ == "__main__":
+    run()

--- a/rios/riostests/teststats.py
+++ b/rios/riostests/teststats.py
@@ -249,22 +249,22 @@ def runOneTest(driverName, creationOptions, fileDtype, scalefactor, offset,
         if stats1 is not None:
             stats2 = getStatsFromArray(outarr, nullVal)
 
-            # This relative tolerance is used for comparing the median and mode, 
-            # because those are approximate only, and the likely error depends on the 
-            # size of the numbers in question (thus it depends on the scalefactor). 
-            # Please do not make it any larger unless you have a really solid reason. 
+            # This relative tolerance is used for comparing the median and mode,
+            # because those are approximate only, and the likely error depends on the
+            # size of the numbers in question (thus it depends on the scalefactor).
+            # Please do not make it any larger unless you have a really solid reason.
             relativeTolerance = 0.3 * scalefactor
             statsOK = compareStats(stats1, stats2, iterationName, relativeTolerance)
             ok = ok and statsOK
         elif not omit:
             msg = "Stats missing, even though not omitting them"
-            riostestutils.report(TESTNAME, 
+            riostestutils.report(TESTNAME,
                 'Iteration={}\n{}'.format(iterationName, msg))
             ok = False
 
         if omit and stats1 is not None:
             msg = "Stats present, even though directed to omit"
-            riostestutils.report(TESTNAME, 
+            riostestutils.report(TESTNAME,
                 'Iteration={}\n{}'.format(iterationName, msg))
             ok = False
 


### PR DESCRIPTION
The GDT_Int8 datatype was added in GDAL 3.7 (May 2023), but RIOS had never provided any support for it.
https://gdal.org/en/stable/development/rfc/rfc87_signed_int8.html

Up until we changed to use GDAL's typecode functions (https://github.com/ubarsc/rios/pull/75), trying to use it (by setting numpy.int8 output arrays) would have caused an exception, but after that, it seems it was possible to use it and produce wrong or misleading output files. 

This PR adds full support for GDT_Int8, and also fixes https://github.com/ubarsc/rios/issues/146. 

We never supported the use of PIXELTYPE=SIGNEDBYTE, and given that GDT_Int8 supercedes this, we never will.
