### PR TITLE
fix docstring for makeExtraParams_PrivateCluster. Document blocktl and blocktr in readerinfo

### DIFF
--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -692,8 +692,8 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             Required. ARN for an AWS role. This allows your code to use AWS
             services. This role should include policies such as AmazonS3FullAccess,
             covering any AWS services your compute workers will need.
-        subnets : list of str
-            Required. List of subnet ID strings associated with the VPC in which
+        subnet : str
+            A subnet ID string associated with the VPC in which
             workers will run.
         securityGroups : list of str
             Required. List of security group IDs associated with the VPC.

--- a/rios/readerinfo.py
+++ b/rios/readerinfo.py
@@ -125,7 +125,9 @@ class ReaderInfo(object):
         self.blockwidth = None
         self.blockheight = None
         
+        #: top left coordinate of current block as a :class:`rios.imageio.Coord`
         self.blocktl = None
+        #: bottom right coordinate of current block as a :class:`rios.imageio.Coord`
         self.blockbr = None
         
         self.xblock = None
@@ -243,7 +245,7 @@ class ReaderInfo(object):
         be what one wants. 
         
         """
-        (tl, _) = (self.blocktl, self.blockbr)
+        tl = self.blocktl
         (nCols, nRows) = self.getBlockSize()
         nCols += 2 * self.overlap
         nRows += 2 * self.overlap


### PR DESCRIPTION
makeExtraParams_PrivateCluster had `subnets` rather than `subnet`. 

Also document `blocktl` and `blocktr` - sometimes you just need the extent of the current tile.