### PR TITLE
Safe wait for finish of cluster ECS tasks

### DIFF
--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -468,19 +468,9 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         Poll the given cluster until the number of tasks reaches zero
         """
         taskCount = self.getClusterTaskCount()
-        startTime = time.time()
-        timeout = 20
-        timeExceeded = False
-        while ((taskCount > 0) and (not timeExceeded)):
+        while (taskCount > 0):
             time.sleep(5)
             taskCount = self.getClusterTaskCount()
-            timeExceeded = (time.time() > (startTime + timeout))
-
-        # If we exceeded timeout without reaching zero,
-        # raise an exception
-        if timeExceeded and (taskCount > 0):
-            msg = ("Cluster task count timeout ({} seconds). ".format(timeout))
-            raise rioserrors.TimeoutError(msg)
 
     def createTaskDef(self):
         """

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -456,13 +456,6 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             instanceCount = self.getClusterInstanceCount(clusterName)
             timeExceeded = (time.time() > (startTime + timeout))
 
-        # If we exceeded timeout without reaching endInstanceCount,
-        # raise an exception
-        if timeExceeded and (instanceCount != endInstanceCount):
-            msg = ("Cluster instance count timeout ({} seconds). ".format(timeout) +
-                   "See extraParams['waitClusterInstanceCountTimeout']")
-            raise rioserrors.TimeoutError(msg)
-
     def waitClusterTasksFinished(self):
         """
         Poll the given cluster until the number of tasks reaches zero

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -468,9 +468,13 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         Poll the given cluster until the number of tasks reaches zero
         """
         taskCount = self.getClusterTaskCount()
-        while (taskCount > 0):
+        startTime = time.time()
+        timeout = 50
+        timeExceeded = False
+        while ((taskCount > 0) and (not timeExceeded)):
             time.sleep(5)
             taskCount = self.getClusterTaskCount()
+            timeExceeded = (time.time() > (startTime + timeout))
 
     def createTaskDef(self):
         """

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -347,6 +347,10 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         """
         Shut down the workers
         """
+        # The order in which the various parts are shut down is critical. Please
+        # do not change this unless you are really sure.
+        # It is also important that all of it happen, so please avoid having
+        # any exceptions raised from within this routine.
         self.forceExit.set()
         self.makeOutObjList()
         self.waitClusterTasksFinished()
@@ -468,6 +472,9 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
             time.sleep(5)
             taskCount = self.getClusterTaskCount()
             timeExceeded = (time.time() > (startTime + timeout))
+
+        # If timeExceeded, then one or more tasks is probably stopped but
+        # not exited. In this case, it is safe to proceed to delete_cluster.
 
     def createTaskDef(self):
         """


### PR DESCRIPTION
This solves a problem reported by @gillins with error handling in CW_ECS in a private cluster.

The offending traceback is shown below
```
Error in compute worker 1
Traceback (most recent call last):
File "/oziussw/local/lib/python3.13/dist-packages/rios/cmdline/rios_computeworker.py", line 92, in riosRemoteComputeWorker
rtn = applier.apply_singleCompute(userFunction, infiles, outfiles,
otherArgs, controls, allInfo, workinggrid, blockList,
outBlockBuffer, inBlockBuffer, workerID, forceExit)
File "/oziussw/local/lib/python3.13/dist-packages/rios/applier.py", line 1082, in apply_singleCompute
userFunction(*userArgs)
~~~~~~~~~~~~^^^^^^^^^^^
File "/oziussw/bin/sharpenRF.py", line 93, in _localRegression
x = np.transpose(inputs.sharp.reshape(inputs.sharp.shape[0], -1).astype(np.float32)) + nd232112
^^^^^^^^
NameError: name 'nd232112' is not defined
Traceback (most recent call last):
File "/oziussw/local/lib/python3.13/dist-packages/rios/applier.py", line 1201, in apply_multipleCompute
raise rioserrors.WorkerExceptionError(msg)
rios.rioserrors.WorkerExceptionError: The preceding exception was raised in a worker
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
File "/oziussw/bin/sharpenRF.py", line 266, in <module>
main()
~~~~^^
File "/oziussw/bin/sharpenRF.py", line 262, in main
sharpenHeight(cmdargs)
~~~~~~~~~~~~~^^^^^^^^^
File "/oziussw/bin/sharpenRF.py", line 227, in sharpenHeight
rtn = applier.apply(_localRegression, infiles, outfiles, otherargs, controls=controls)
File "/oziussw/local/lib/python3.13/dist-packages/rios/applier.py", line 991, in apply
rtn = apply_multipleCompute(userFunction, infiles, outfiles,
otherArgs, controls, allInfo, workinggrid, blockList)
File "/oziussw/local/lib/python3.13/dist-packages/rios/applier.py", line 1209, in apply_multipleCompute
computeMgr.shutdown()
~~~~~~~~~~~~~~~~~~~^^
File "/oziussw/local/lib/python3.13/dist-packages/rios/computemanager.py", line 349, in shutdown
self.waitClusterTasksFinished()
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
File "/oziussw/local/lib/python3.13/dist-packages/rios/computemanager.py", line 480, in waitClusterTasksFinished
raise rioserrors.TimeoutError(msg)
rios.rioserrors.TimeoutError: Cluster task count timeout (20 seconds).
```
This resulted in the main thread hanging, and the EC2 instances remaining active. 

This was triggered by a syntax error in the user function. The ECS tasks stopped, but with an error, and never actually exited. The wait for all tasks to complete would therefore reach its timeout, and raise an exception. This mean that the rest of the shutdown never completed, including, most critically, the NetworkDataChannel shutdown and the termination of EC2 instances, so all these remained active. The NetworkDataChannel thus prevented the main thread from exiting, and so the main script hung.

All rather disasterous, but the fix is simply that nothing in the shutdown should raise an exception. So, I have corrected this, and added some comments to explain that this is important.