### PR TITLE
Failsafe to terminate orphaned EC2 instances

### DIFF
--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -444,8 +444,8 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
 
         for instanceId in instanceIdList:
             cloudwatchClient.put_metric_alarm(
-                AlarmName=f"RIOS-idleinstancefailsafe-{instanceId}",
-                AlarmDescription="Fail-safe to kill orphaned instance",
+                AlarmName="RIOS-idleinstancefailsafe",
+                AlarmDescription="Fail-safe to terminate orphaned instance",
                 ActionsEnabled=True,
                 AlarmActions=[f"arn:aws:automate:{regionName}:ec2:terminate"],
                 MetricName="CPUUtilization",

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -443,7 +443,7 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         regionName = self.session.region_name
 
         for instanceId in instanceIdList:
-            # NB AlarmName must be unique, so we include instanceId
+            # NB. AlarmName must be unique, so we include instanceId
             cloudwatchClient.put_metric_alarm(
                 AlarmName=f"RIOS-idleinstancefailsafe-{instanceId}",
                 AlarmDescription="Fail-safe to terminate orphaned instance",

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -443,8 +443,9 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         regionName = self.session.region_name
 
         for instanceId in instanceIdList:
+            # NB AlarmName must be unique, so we include instanceId
             cloudwatchClient.put_metric_alarm(
-                AlarmName="RIOS-idleinstancefailsafe",
+                AlarmName=f"RIOS-idleinstancefailsafe-{instanceId}",
                 AlarmDescription="Fail-safe to terminate orphaned instance",
                 ActionsEnabled=True,
                 AlarmActions=[f"arn:aws:automate:{regionName}:ec2:terminate"],


### PR DESCRIPTION
In the event of un-caught errors when running CW_ECS in a private EC2 cluster, it is possible for EC2 instances to be left orphaned. No parts of RIOS are still running, but they instances are still up, and costing money. This PR sets a CloudWatch Alarm to terminate each instance if it falls idle for 24 hours, which should only happen in this error situation.