### PR TITLE
Sensible error message in ratapplier when column array is unknown type

### DIFF
--- a/rios/ratapplier.py
+++ b/rios/ratapplier.py
@@ -521,6 +521,10 @@ class RatBlockAssociation(object):
             # Check if the column needs to be created
             if columnName not in self.Z__gdalHandles.columnNdxByName:
                 columnType = rat.inferColumnType(dataBlock)
+                if columnType is None:
+                    msg = "Can't infer GFT type from {} for column '{}'".format(
+                        type(dataBlock[0]), columnName)
+                    raise rioserrors.AttributeTableTypeError(msg)
                 columnUsage = self.getUsage(columnName)
                 gdalRat.CreateColumn(columnName, columnType, columnUsage)
                 # Work out the new column index


### PR DESCRIPTION
I tripped over this when using ratapplier to write a column of type bool. The function to infer the GFT_* column type doesn't know about it, and instead I got an obscure exception from deep inside GDAL. This is a little clearer.

It is also possible we should infer GFT_Integer from 'bool', but that is a separate question for another time. 