### PR TITLE
CW_ECS waitClusterTasksFinished. Increase timeout, and catch all exceptions

### DIFF
--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -477,7 +477,7 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         """
         taskCount = self.getClusterTaskCount()
         startTime = time.time()
-        timeout = 180
+        timeout = 600
         timeExceeded = False
         while ((taskCount > 0) and (not timeExceeded)):
             time.sleep(5)

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -490,7 +490,16 @@ class ECSComputeWorkerMgr(ComputeWorkerManager):
         # delete the cluster
         if timeExceeded:
             for taskArn in self.taskArnList:
-                self.ecsClient.stop_task(cluster=self.clusterName, task=taskArn)
+                # We are trying to avoid any exceptions raised from within
+                # shutdown, so trap all of them.
+                try:
+                    self.ecsClient.stop_task(cluster=self.clusterName,
+                        task=taskArn)
+                except Exception as e:
+                    # I am unsure if I should just silently ignore any exception
+                    # raised here, but for now I am going to print it to stderr.
+                    msg = f"Exception '{e}' raised while stopping ECS task"
+                    print(msg, file=sys.stderr)
 
     def createTaskDef(self):
         """


### PR DESCRIPTION
As reported by @gillins.

For CW_ECS, waiting for the individual cluster tasks to exit is important, so that we don't try to delete the cluster before they are completed. However, it is not clear how long we should wait before concluding that a task is not going to exit on its own. I had guessed 3 minutes, but it appears this is not long enough, so I have upped it to 10 minutes. 

I don't think it makes sense for this timeout to be configurable, because it is very subtle and most users won't know what to do with it anyway. I am happy to entertain discussion on this point, though, so feel free to have an opinion.
