### PR TITLE
Minor doco

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,30 @@
 # RIOS - Raster I/O Simplification
-A set of Python modules which makes it easy to write raster processing 
-code in Python. It is built on top of [GDAL](https://www.gdal.org).
+A set of Python modules which makes it easy to write raster processing code in Python. It is built on top of [GDAL](https://www.gdal.org).
+
+Raster data is read from input files and presented to the user as numpy arrays for processing. Output raster data is taken as numpy arrays and written to output files. The user provides a Python function to perform the desired processing with these numpy arrays.
+
+These [simple examples](https://www.rioshome.org/en/latest/applierexamples.html) demonstrate the main ideas.
 
 ## Features
-- Handles the details of opening and closing files.
-- Checks alignment of projection and raster grid.
-- Steps through the raster in small blocks to reduce memory requirements.
-- Strong, flexible support for concurrency in reading/computation/writing
+- Handles the details of opening/closing raster files and reading/writing of raster data.
+- Checks agreement of projection and raster grid alignment and extent across the set of input files, reprojecting and/or resampling automatically as required
+- Steps through the raster in small blocks to reduce memory requirements, allowing processing of very large rasters
+- Raster data is presented to the user as numpy arrays, passed to a user-supplied function which performs all processing computation
+- Strong, flexible support for concurrency in reading/computation/writing for efficient use of available hardware (e.g. multiple CPU cores, AWS Fargate/ECS, and others).
 - *and more...*
 
 This allows the programmer to concentrate on the processing involved.
 
-RIOS was written for our own use, and comes without any warranty or assurance 
-that it might even be useful. But if anyone else is silly enough to want it, 
-they are welcome to use it. 
+RIOS comes without any warranty or assurance that it might be useful. Anyone doing raster processing is welcome to use it and build on it.
 
-## Download
-- Click on the Releases link and select the latest tarball
-- Also available from conda-forge
+## Download/Install
+- For source download, click on the [Releases](https://github.com/ubarsc/rios/releases) link and select the latest tarball
+- Direct install is available with conda (from conda-forge), and with the Spack package manager
+
+See [Downloads](https://www.rioshome.org/en/latest/#downloads) for full details
 
 ## Documentation
-Sphinx documentation is available at [www.rioshome.org](https://www.rioshome.org/)
+Full Sphinx documentation is available at [www.rioshome.org](https://www.rioshome.org/)
 
 ## License
 GPL 3, *see LICENSE.txt* 

--- a/doc/source/concurrency.rst
+++ b/doc/source/concurrency.rst
@@ -200,11 +200,16 @@ This section describes the details of each of the different kinds of
 compute worker. The simplest compute worker kind is CW_THREADS, and is likely
 to be the most useful for the majority of users.
 
-The other compute worker kinds should be regarded as somewhat experimental.
-They are all intended to provide ways of making greater use of a larger
+For users of Amazon AWS cloud computing, CW_ECS supports ECS clusters in
+various configurations.
+
+The CW_PBS & CW_SLURM kinds should be regarded as somewhat experimental.
+They are intended to provide ways of making greater use of a larger
 cluster of machines, which is managed by some kind of batch system, but
 the complexities of this may mean they are more trouble than they are worth.
 Feedback is welcome.
+
+Suggestions to support other compute worker kinds are welcome.
 
 The degree of speed-up achieved by using multiple compute workers follows a
 theoretical 1/N curve. So, if the number of compute workers is N, the total
@@ -340,8 +345,8 @@ taskRole.
 
 **CW_AWSBATCH**
 
-This should be regarded as obsolete, and will probably be deprecated in future.
-Its use is not recommended.
+This should be regarded as obsolete. It is deprecated and will probably be
+removed in future. Its use is not recommended.
 
 Each compute worker runs as a separate AWS Batch job. Specific AWS infrastructure
 needs to be available. See :doc:`awsbatch` for more information. Note that no
@@ -354,6 +359,8 @@ expect. This network socket will use a port number in the range 30000-50000,
 so the batch nodes should be configured to allow this.
 
 **CW_PBS**
+
+Please note that this is somewhat experimental.
 
 Each compute worker runs as a separate job on a PBS batch queue. This is one
 way to make effective use of a large cluster which is only accessible through
@@ -429,6 +436,8 @@ this should be a dictionary, with one or more of the following entries
      - As for cmdPrefix, but appended to the end of the command.
 
 **CW_SLURM**
+
+Please note that this is somewhat experimental.
 
 This behaves exactly like the CW_PBS compute workers, but using the SLURM
 batch queue system instead. See the PBS description.

--- a/rios/__init__.py
+++ b/rios/__init__.py
@@ -18,6 +18,22 @@ Rios is built on top of GDAL, and handles, among other things:
 The main starting point is the rios.applier.apply function.
 
 """
+# This file is part of RIOS - Raster I/O Simplification
+# Copyright (C) 2012  Sam Gillingham, Neil Flood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 # Used to fill in the rest of the comparison methods
 from functools import total_ordering
 

--- a/rios/cmdline/rios_computeworker.py
+++ b/rios/cmdline/rios_computeworker.py
@@ -2,6 +2,22 @@
 """
 Main script for a compute worker running in a separate process.
 """
+# This file is part of RIOS - Raster I/O Simplification
+# Copyright (C) 2012  Sam Gillingham, Neil Flood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import argparse
 
 from osgeo import gdal

--- a/rios/computemanager.py
+++ b/rios/computemanager.py
@@ -3,6 +3,22 @@ The ComputeWorkerManager abstract base class is for creating and managing
 a set of compute workers. Each different computeWorkerKind is implemented
 as a concrete subclass of this. All these classes are found in this module.
 """
+# This file is part of RIOS - Raster I/O Simplification
+# Copyright (C) 2012  Sam Gillingham, Neil Flood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import sys
 import os
 from abc import ABC, abstractmethod

--- a/rios/structures.py
+++ b/rios/structures.py
@@ -3,6 +3,22 @@ Many of the major data structures to support the new applier parallel
 architecture.
 
 """
+# This file is part of RIOS - Raster I/O Simplification
+# Copyright (C) 2012  Sam Gillingham, Neil Flood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 import os
 import socket
 from multiprocessing.managers import BaseManager


### PR DESCRIPTION
The README has always been a bit sparse, and did not really give a clear picture of what RIOS does. I have tried to fix that, without making it too verbose. Hopefully this helps to create a better first impression.

Also updates a couple of minor details on compute worker kinds, and adds the GPL license summary to a few main Python files (my fault - they were all ones I had created :-)
