### PR TITLE
Cope with proposed change in gdal.Open (gdal/pull/14763)

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -38,7 +38,7 @@ jobs:
         testrios
 
   tests-ubuntu-no-conda:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -46,10 +46,9 @@ jobs:
       shell: bash -l {0}
       run: |
         sudo apt-get update -y
-        sudo apt-get install -y --no-install-recommends \
+        sudo apt-get install -y --no-install-recommends python3-zarr \
           python3-gdal python3-cloudpickle python3-scipy python3-pip
         pip install --upgrade pip
-        pip install zarr
         pip install git+https://github.com/ubarsc/ratzarr.git
     - name: Test with testrios
       shell: bash -l {0}

--- a/rios/fileinfo.py
+++ b/rios/fileinfo.py
@@ -64,7 +64,8 @@ class ImageInfo(object):
 
     """
     def __init__(self, filename, omitPerBand=False):
-        ds = gdal.Open(str(filename), gdal.GA_ReadOnly)
+        openFlags = (gdal.OF_READONLY | gdal.OF_RASTER)
+        ds = gdal.OpenEx(str(filename), openFlags)
         if ds is None:
             raise rioserrors.FileOpenError("Unable to open file %s"%filename)
 


### PR DESCRIPTION
Upcoming GDAL pull request https://github.com/OSGeo/gdal/pull/14763 will cause a change in behaviour of `gdal.Open`. We rely on the old behaviour in `rios.applier.readAllImgInfo`, where we expect that the `rios.fileinfo.ImageInfo` class will raise an exception if called on a vector file. Under the new behaviour, this would no longer be true.

This PR changes the ImageInfo constructor to explicitly use `gdal.OpenEx` with suitable flags to reproduce the expected behaviour. This appears to work fine under current versions of GDAL. 

I think this is the only place that should be affected by the change, most uses of `gdal.Open` should be fine.