### PR TITLE
Extra checks on use of footprint type

### DIFF
--- a/rios/applier.py
+++ b/rios/applier.py
@@ -243,6 +243,12 @@ class ApplierControls(object):
             msg = "No input files, but footprint is not BOUNDS_FROM_REFERENCE"
             raise ValueError(msg)
 
+        # No-input case needs some reference grid
+        if (len(infiles) == 0 and self.referenceImage is None and
+                self.referencePixgrid is None):
+            msg = "No input files, but no reference image or pixgrid given"
+            raise ValueError(msg)
+
     def setOverlap(self, overlap):
         """
         Set the overlap to the given value.

--- a/rios/applier.py
+++ b/rios/applier.py
@@ -36,7 +36,7 @@ from .imagereader import DEFAULTLOGGINGSTREAM                         # noqa: F4
 from .imagereader import readBlockAllFiles, ReadWorkerMgr, specialProjFixes
 from .imagewriter import DEFAULTDRIVERNAME, DEFAULTCREATIONOPTIONS    # noqa: F401
 from .imagewriter import writeBlock, closeOutfiles, dfltDriverOptions  # noqa: F401
-from .imageio import INTERSECTION, UNION, BOUNDS_FROM_REFERENCE       # noqa: F401
+from .imageio import INTERSECTION, UNION, BOUNDS_FROM_REFERENCE
 from .calcstats import DEFAULT_OVERVIEWLEVELS, DEFAULT_MINOVERVIEWDIM
 from .calcstats import DEFAULT_OVERVIEWAGGREGRATIONTYPE               # noqa: F401
 from .calcstats import SinglePassManager
@@ -234,6 +234,14 @@ class ApplierControls(object):
                 msg = ("Approximate stats requires pyramid layers, " +
                        "which have been omitted")
                 raise ValueError(msg)
+
+        # Checks on footprint type
+        if self.footprint not in [INTERSECTION, UNION, BOUNDS_FROM_REFERENCE]:
+            msg = f"Unknown footprint type {self.footprint}"
+            raise ValueError(msg)
+        if len(infiles) == 0 and self.footprint != BOUNDS_FROM_REFERENCE:
+            msg = "No input files, but footprint is not BOUNDS_FROM_REFERENCE"
+            raise ValueError(msg)
 
     def setOverlap(self, overlap):
         """

--- a/rios/structures.py
+++ b/rios/structures.py
@@ -343,6 +343,9 @@ class FilenameAssociations(object):
 
     Indexing is read-only, and cannot be used to set filenames.
 
+    Using the len() function will return the number of individual files,
+    accumulating over single entries and list entries.
+
     """
     def __getitem__(self, key):
         if isinstance(key, tuple):
@@ -385,6 +388,16 @@ class FilenameAssociations(object):
 
     def __iter__(self):
         return FilenameAssocIterator(self)
+
+    def __len__(self):
+        count = 0
+        for key in self.__dict__:
+            entry = self.__dict__[key]
+            if isinstance(entry, str):
+                count += 1
+            elif isinstance(entry, list):
+                count += len(entry)
+        return count
 
 
 class FilenameAssocIterator(object):


### PR DESCRIPTION
Mainly this is to show a better error message when the user runs with no input files but has not set footprint to be BOUNDS_FROM_REFERENCE.

I did consider just having the findCommonRegion function pretend they had, when there are no inputs, but figured that it was better to tell them what they should be doing, rather than hide the fact. They might just have forgotten to include any inputs. 