### PR TITLE
Minor tidying of the code for default creation options

### DIFF
--- a/doc/source/environmentvars.rst
+++ b/doc/source/environmentvars.rst
@@ -9,8 +9,8 @@ RIOS honours the following environment variables which can be used to override d
 +===============================+=======================================+================+=======================+
 |RIOS_DFLT_DRIVER               |The name of the default GDAL driver    |HFA             | drivername            |
 +-------------------------------+---------------------------------------+----------------+-----------------------+
-|RIOS_DFLT_DRIVEROPTIONS        |Creation Options to be passed to GDAL. |COMPRESSED=TRUE | creationoptions       |
-|                               |Can be 'None'. This is now deprecated, |IGNOREUTM=TRUE  |                       |
+|RIOS_DFLT_DRIVEROPTIONS        |Creation Options to be passed to GDAL. |COMPRESSED=YES  | creationoptions       |
+|                               |Can be 'None'. This is now deprecated, |IGNOREUTM=YES   |                       |
 |                               |in favour of RIOS_DFLT_CREOPT_*        |                |                       |
 +-------------------------------+---------------------------------------+----------------+-----------------------+
 |RIOS_DFLT_CREOPT_<driver>      |Driver-specific creation options.      |From generic    |creationoptions should |
@@ -19,12 +19,12 @@ RIOS honours the following environment variables which can be used to override d
 |                               |Can be specified for any driver,       |                |                       |
 |                               |but defaults are given as below        |                |                       |
 +-------------------------------+---------------------------------------+----------------+-----------------------+
-|RIOS_DFLT_CREOPT_HFA           | Default creation options for HFA      |COMPRESS=YES    |                       |
-|                               |                                       |IGNOREUTM=TRUE  |                       |
+|RIOS_DFLT_CREOPT_HFA           | Default creation options for HFA      |COMPRESSED=YES  |                       |
+|                               |                                       |IGNOREUTM=YES   |                       |
 +-------------------------------+---------------------------------------+----------------+-----------------------+
 |RIOS_DFLT_CREOPT_GTiff         | Default creation options for GTiff    |TILED=YES       |                       |
 |                               |                                       |INTERLEAVE=BAND |                       |
-|                               |                                       |COMPRESS=LZW    |                       |
+|                               |                                       |COMPRESS=DEFLATE|                       |
 |                               |                                       |BIGTIFF=IF_SAFER|                       |
 +-------------------------------+---------------------------------------+----------------+-----------------------+
 |RIOS_DFLT_FOOTPRINT            | 0 for intersection, 1 for union       | Intersection   | footprint             |

--- a/rios/imagewriter.py
+++ b/rios/imagewriter.py
@@ -65,18 +65,18 @@ def setDefaultDriver():
     DEFAULTDRIVERNAME = os.getenv('RIOS_DFLT_DRIVER', default='HFA')
     creationOptionsStr = os.getenv('RIOS_DFLT_DRIVEROPTIONS')
     if creationOptionsStr is not None:
-        if creationOptionsStr == 'None':
-            # hack for KEA which needs no creation options
-            # and LoadLeveler which deletes any env variables
-            # set to an empty values
-            DEFAULTCREATIONOPTIONS = []
-        else:
-            DEFAULTCREATIONOPTIONS = creationOptionsStr.split()
+        DEFAULTCREATIONOPTIONS = creationOptionsStr.split()
     else:
         # To cope with the old behaviour, set something sensible for HFA, but not
-        # otherwise
+        # otherwise.
+        # The IGNOREUTM=YES is there to switch off a minor kludge in GDAL's
+        # HFA driver. By default, it will check any Transverse Mercator
+        # projection, and if its parameters match a standard UTM zone, it
+        # re-states the projection as literal UTM. This was originally because
+        # Imagine was not good at matching equivalent projections. This is no
+        # longer true, and we choose to disable that behaviour by default.
         if DEFAULTDRIVERNAME == "HFA":
-            DEFAULTCREATIONOPTIONS = ['COMPRESSED=TRUE', 'IGNOREUTM=TRUE']
+            DEFAULTCREATIONOPTIONS = ['COMPRESSED=YES', 'IGNOREUTM=YES']
         else:
             DEFAULTCREATIONOPTIONS = []
     
@@ -87,7 +87,8 @@ def setDefaultDriver():
     # Start with the old generic default options, applied to the default driver
     dfltDriverOptions[DEFAULTDRIVERNAME] = DEFAULTCREATIONOPTIONS
     # Load some others which we wish to have as defaults, even if not set by the environment
-    dfltDriverOptions['GTiff'] = ['TILED=YES', 'COMPRESS=LZW', 'INTERLEAVE=BAND', 'BIGTIFF=IF_SAFER']
+    dfltDriverOptions['GTiff'] = ['TILED=YES', 'COMPRESS=DEFLATE',
+        'INTERLEAVE=BAND', 'BIGTIFF=IF_SAFER']
     # Now load any which are specified by environment variables, of the
     # form RIOS_DFLT_CREOPT_<drivername>
     driverOptVarPrefix = 'RIOS_DFLT_CREOPT_'
@@ -95,11 +96,7 @@ def setDefaultDriver():
         if varname.startswith(driverOptVarPrefix):
             drvrName = varname[len(driverOptVarPrefix):]
             optionsStr = os.getenv(varname)
-            if optionsStr == 'None':
-                # Repeat that ridiculous hack for the KEA/LoadLeveler combination
-                dfltDriverOptions[drvrName] = []
-            else:
-                dfltDriverOptions[drvrName] = optionsStr.split()
+            dfltDriverOptions[drvrName] = optionsStr.split()
 
 
 setDefaultDriver()


### PR DESCRIPTION
This PR is just tidying up a few old details in the function which sets up default creation options, as follows

- Change the default compression for GTiff to "COMPRESS=DEFLATE". This appears to be better than "LZW", which we have had for a long time.
- Change the default HFA creation options to use "YES" instead of "TRUE". They are equivalent in GDAL's code, but the GDAL doco uses "YES", so I thought it better to match that. When I was reading it, I had to go check to make sure it really would be the same, so easier not to be confusing in the first place.
- Add a comment to explain why the default HFA options include IGNOREUTM=YES. This is a very old leftover, of little relevance nowadays, but I wanted to be clear about why it is there.
- Remove a now-redundant hack which ensured that the default creation options was never left as None. This now happens in `openOutfile()`, as a result of the changes made in the version 2.0 update. There is simply a default of `[]` whenever there is no matching default creation options for a given driver. The old hack had been added for certain compute environments which deleted environment variables set to empty, but the new code copes with that situation for free.