### PR TITLE
Minor preparation for Zarr output files

### DIFF
--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -497,6 +497,7 @@ class SinglePassManager:
                 # written directly.
                 imgfile = tmpfileMgr.mktempfile(prefix='pyrcheck_',
                     suffix=suffix)
+                os.remove(imgfile)
                 arr = numpy.full((nrows, ncols), fillVal, dtype=numpy.uint8)
                 ds = drvr.Create(imgfile, ncols, nrows, 1, gdal.GDT_Byte)
                 band = ds.GetRasterBand(1)
@@ -518,6 +519,7 @@ class SinglePassManager:
                 # If the overview array is full of the fill value, then it works
                 supported = (arr_sub2 == fillVal).all()
                 driverSupportsPyramids[driverName] = supported
+
         return driverSupportsPyramids
 
     def initFor(self, ds, symbolicName, seqNum, arr):

--- a/rios/structures.py
+++ b/rios/structures.py
@@ -30,6 +30,7 @@ import contextlib
 import queue
 import tempfile
 import traceback
+import shutil
 
 import numpy
 from osgeo import gdal
@@ -1128,6 +1129,8 @@ class TempfileManager:
         for filename in self.tempfileList:
             try:
                 os.remove(filename)
+            except IsADirectoryError:
+                shutil.rmtree(filename)
             except FileNotFoundError:
                 pass
 


### PR DESCRIPTION
If the output driver is Zarr, there were a couple of things which do not cope.

- The per-driver check for direct writing of pyramids creates a temp file, but the Zarr Create function won't over-write this, so remove it first
- The TempfileManager cleanup function removes files, but needs a fallback in case it has to remove a directory (such as a Zarr file)

There are still other problems with the Zarr driver, so we may have more to do before we can actually use it, but these changes seem good anyway.