### PR TITLE
Add const.py, move default creation options into it. 

### DIFF
--- a/doc/source/environmentvars.rst
+++ b/doc/source/environmentvars.rst
@@ -27,6 +27,9 @@ RIOS honours the following environment variables which can be used to override d
 |                               |                                       |COMPRESS=DEFLATE|                       |
 |                               |                                       |BIGTIFF=IF_SAFER|                       |
 +-------------------------------+---------------------------------------+----------------+-----------------------+
+|RIOS_DFLT_CREOPT_Zarr          | Default creation options for Zarr     |COMPRESS=BLOSC  |                       |
+|                               |                                       |FORMAT=ZARR_V3  |                       |
++-------------------------------+---------------------------------------+----------------+-----------------------+
 |RIOS_DFLT_FOOTPRINT            | 0 for intersection, 1 for union       | Intersection   | footprint             |
 +-------------------------------+---------------------------------------+----------------+-----------------------+
 |RIOS_DFLT_BLOCKXSIZE           | Window X size                         | 256            | windowxsize           |

--- a/doc/source/environmentvars.rst
+++ b/doc/source/environmentvars.rst
@@ -10,8 +10,8 @@ RIOS honours the following environment variables which can be used to override d
 |RIOS_DFLT_DRIVER               |The name of the default GDAL driver    |HFA             | drivername            |
 +-------------------------------+---------------------------------------+----------------+-----------------------+
 |RIOS_DFLT_DRIVEROPTIONS        |Creation Options to be passed to GDAL. |COMPRESSED=YES  | creationoptions       |
-|                               |Can be 'None'. This is now deprecated, |IGNOREUTM=YES   |                       |
-|                               |in favour of RIOS_DFLT_CREOPT_*        |                |                       |
+|                               |This is now deprecated, in favour of   |IGNOREUTM=YES   |                       |
+|                               |RIOS_DFLT_CREOPT_*                     |                |                       |
 +-------------------------------+---------------------------------------+----------------+-----------------------+
 |RIOS_DFLT_CREOPT_<driver>      |Driver-specific creation options.      |From generic    |creationoptions should |
 |                               |These are new, and intended to         |variable        |be None to use these   |

--- a/rios/applier.py
+++ b/rios/applier.py
@@ -34,9 +34,9 @@ from .imagereader import DEFAULTFOOTPRINT, DEFAULTWINDOWXSIZE
 from .imagereader import DEFAULTWINDOWYSIZE, DEFAULTOVERLAP
 from .imagereader import DEFAULTLOGGINGSTREAM                         # noqa: F401
 from .imagereader import readBlockAllFiles, ReadWorkerMgr, specialProjFixes
-from .imagewriter import DEFAULTDRIVERNAME, DEFAULTCREATIONOPTIONS    # noqa: F401
-from .imagewriter import writeBlock, closeOutfiles, dfltDriverOptions  # noqa: F401
-from .imageio import INTERSECTION, UNION, BOUNDS_FROM_REFERENCE
+from .imagewriter import writeBlock, closeOutfiles
+from .const import dfltDriverOptions, DEFAULTDRIVERNAME, DEFAULTCREATIONOPTIONS  # noqa: F401
+from .const import INTERSECTION, UNION, BOUNDS_FROM_REFERENCE
 from .calcstats import DEFAULT_OVERVIEWLEVELS, DEFAULT_MINOVERVIEWDIM
 from .calcstats import DEFAULT_OVERVIEWAGGREGRATIONTYPE               # noqa: F401
 from .calcstats import SinglePassManager

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -27,6 +27,7 @@ from osgeo import gdal
 
 from . import cuiprogress
 from .rioserrors import ProcessCancelledError, SinglePassActionsError
+from .const import dfltDriverOptions
 
 
 # When calculating overviews (i.e. pyramid layers), default behaviour
@@ -494,9 +495,7 @@ class SinglePassManager:
                 options = controls.getOptionForImagename('creationoptions',
                     symbolicName)
                 if options is None:
-                    # Should be imagewriter.dfltDriverOptions[driverName], but
-                    # that would be a circular import
-                    options = []
+                    options = dfltDriverOptions.get(driverName, [])
                 suffix = ".{}".format(drvr.GetMetadataItem('DMD_EXTENSION'))
 
                 # Create a small test image with a single overview level,

--- a/rios/const.py
+++ b/rios/const.py
@@ -1,0 +1,95 @@
+"""
+This module holds a number of constant values which should be available
+to the rest of the package. This file should not import any other
+part of RIOS. 
+"""
+# This file is part of RIOS - Raster I/O Simplification
+# Copyright (C) 2012  Sam Gillingham, Neil Flood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import os
+
+
+# Definitions for footprint types. These were originally in imageio.py
+INTERSECTION = 0
+UNION = 1
+BOUNDS_FROM_REFERENCE = 2       # Bounds of working region are taken from given reference grid
+
+
+# Per-driver dictionary of default creation options. We pre-load this with
+# options for a few drivers we think are important (to us), but more can be
+# loaded from environment variables $RIOS_DFLT_CREOPT_<drivername>
+dfltDriverOptions = {
+    'HFA': ['COMPRESSED=YES', 'IGNOREUTM=YES'],
+    'GTiff': ['TILED=YES', 'COMPRESS=DEFLATE', 'INTERLEAVE=BAND',
+              'BIGTIFF=IF_SAFER'],
+    'Zarr': ['FORMAT=ZARR_V3', 'COMPRESS=BLOSC']
+}
+
+# N.B. For the default HFA creation options.
+# The IGNOREUTM=YES is there to switch off a minor kludge in GDAL's
+# HFA driver. By default, it will check any Transverse Mercator
+# projection, and if its parameters match a standard UTM zone, it
+# re-states the projection as literal UTM. This was originally because
+# Imagine was not good at matching equivalent projections. This is no
+# longer true, and we choose to disable that behaviour by default.
+
+
+def setDefaultDriver():
+    """
+    Sets some default values into global variables, defining
+    what defaults we should use for GDAL driver. On any given
+    output file these can be over-ridden, and can be over-ridden globally
+    using the environment variables
+
+        * $RIOS_DFLT_DRIVER
+        * $RIOS_DFLT_DRIVEROPTIONS (deprecated)
+        * $RIOS_DFLT_CREOPT_<drivername>
+    
+    If RIOS_DFLT_DRIVER is set, then it should be a gdal short driver name. 
+    If RIOS_DFLT_DRIVEROPTIONS is set, it should be a space-separated list
+    of driver creation options, e.g. "COMPRESS=LZW TILED=YES", and should
+    be appropriate for the selected GDAL driver. This can also be 'None'
+    in which case an empty list of creation options is passed to the driver.
+    
+    The same rules apply to the driver-specific creation options given
+    using $RIOS_DFLT_CREOPT_<driver>. These options are a later paradigm, and 
+    are intended to supercede the previous generic driver defaults. 
+    
+    If not otherwise supplied, the default is to use the HFA driver, with compression. 
+
+    """
+    # The old behaviour just had a single pair of environment variables for
+    # default driver and creation options. If these are set, load them as python
+    # symbols, and store in the per-driver dictionary
+    global DEFAULTDRIVERNAME, DEFAULTCREATIONOPTIONS
+    DEFAULTDRIVERNAME = os.getenv('RIOS_DFLT_DRIVER', default='HFA')
+    creationOptionsStr = os.getenv('RIOS_DFLT_DRIVEROPTIONS')
+    if creationOptionsStr is not None:
+        DEFAULTCREATIONOPTIONS = creationOptionsStr.split()
+        dfltDriverOptions[DEFAULTDRIVERNAME] = DEFAULTCREATIONOPTIONS
+    else:
+        DEFAULTCREATIONOPTIONS = []
+
+    # Now load any driver-specific creation options which are specified by
+    # environment variables, of the form RIOS_DFLT_CREOPT_<drivername>
+    driverOptVarPrefix = 'RIOS_DFLT_CREOPT_'
+    for varname in os.environ:
+        if varname.startswith(driverOptVarPrefix):
+            drvrName = varname[len(driverOptVarPrefix):]
+            optionsStr = os.getenv(varname)
+            dfltDriverOptions[drvrName] = optionsStr.split()
+
+
+setDefaultDriver()

--- a/rios/imageio.py
+++ b/rios/imageio.py
@@ -1,15 +1,13 @@
 """
-The only things of value left in this module are the original definitions of
-UNION, INTERSECTION and BOUNDS_FROM_REFERENCE.
+Almost nothing of value is left in this module. In general, this
+module should be ignored. It remains merely for backward compatibility.
 
-There are also two functions wld2pix and pix2wld, and the Coord class they use.
+There are two functions wld2pix and pix2wld, and the Coord class they use.
 These should also be deprecated, in favour of GDAL's ApplyGeoTransform
 and InvGeoTransform (which they now use internally anyway).
 However, they are used in public-facing ways in the ReaderInfo object,
 so removing them would, in principle, be a breaking change.
 They are harmless enough, so they have been left here.
-
-In general, this module should be ignored.
 
 """
 # This file is part of RIOS - Raster I/O Simplification
@@ -30,10 +28,8 @@ In general, this module should be ignored.
 
 from osgeo import gdal
 
-
-INTERSECTION = 0
-UNION = 1
-BOUNDS_FROM_REFERENCE = 2       # Bounds of working region are taken from given reference grid
+# Import here for backward compatibility
+from .const import INTERSECTION, UNION, BOUNDS_FROM_REFERENCE    # noqa: F401
 
 
 class Coord:

--- a/rios/imagereader.py
+++ b/rios/imagereader.py
@@ -27,7 +27,7 @@ import threading
 import numpy
 from osgeo import gdal, gdal_array, osr
 
-from . import imageio
+from . import const
 from . import rioserrors
 from . import VersionObj
 from .structures import BlockAssociations, WorkerErrorRecord
@@ -40,7 +40,7 @@ if sys.version_info[0] > 2:
     basestring = str
 
 DEFAULTFOOTPRINT = int(os.getenv('RIOS_DFLT_FOOTPRINT', 
-                            default=imageio.INTERSECTION))
+                            default=const.INTERSECTION))
 DEFAULTWINDOWXSIZE = int(os.getenv('RIOS_DFLT_BLOCKXSIZE', default=256))
 DEFAULTWINDOWYSIZE = int(os.getenv('RIOS_DFLT_BLOCKYSIZE', default=256))
 DEFAULTOVERLAP = int(os.getenv('RIOS_DFLT_OVERLAP', default=0))
@@ -237,7 +237,7 @@ def openForWorkingGrid(filename, workinggrid, fileInfo, controls,
         gridList = [workinggrid, vectorPixgrid]
         try:
             commonRegion = findCommonRegion(gridList, vectorPixgrid,
-                combine=imageio.INTERSECTION)
+                combine=const.INTERSECTION)
         except rioserrors.IntersectionError:
             commonRegion = None
         dtype = controls.getOptionForImagename('vectordatatype', symbolicName)

--- a/rios/imagewriter.py
+++ b/rios/imagewriter.py
@@ -31,75 +31,7 @@ from . import rioserrors
 from . import rat
 from . import calcstats
 from . import fileinfo
-
-
-def setDefaultDriver():
-    """
-    Sets some default values into global variables, defining
-    what defaults we should use for GDAL driver. On any given
-    output file these can be over-ridden, and can be over-ridden globally
-    using the environment variables
-
-        * $RIOS_DFLT_DRIVER
-        * $RIOS_DFLT_DRIVEROPTIONS
-        * $RIOS_DFLT_CREOPT_<drivername>
-    
-    If RIOS_DFLT_DRIVER is set, then it should be a gdal short driver name. 
-    If RIOS_DFLT_DRIVEROPTIONS is set, it should be a space-separated list
-    of driver creation options, e.g. "COMPRESS=LZW TILED=YES", and should
-    be appropriate for the selected GDAL driver. This can also be 'None'
-    in which case an empty list of creation options is passed to the driver.
-    
-    The same rules apply to the driver-specific creation options given
-    using $RIOS_DFLT_CREOPT_<driver>. These options are a later paradigm, and 
-    are intended to supercede the previous generic driver defaults. 
-    
-    If not otherwise supplied, the default is to use the HFA driver, with compression. 
-    
-    The code here is more complex than desirable, because it copes with legacy behaviour
-    in the absence of the environment variables, and in the absence of the driver-specific
-    option variables. 
-        
-    """
-    global DEFAULTDRIVERNAME, DEFAULTCREATIONOPTIONS
-    DEFAULTDRIVERNAME = os.getenv('RIOS_DFLT_DRIVER', default='HFA')
-    creationOptionsStr = os.getenv('RIOS_DFLT_DRIVEROPTIONS')
-    if creationOptionsStr is not None:
-        DEFAULTCREATIONOPTIONS = creationOptionsStr.split()
-    else:
-        # To cope with the old behaviour, set something sensible for HFA, but not
-        # otherwise.
-        # The IGNOREUTM=YES is there to switch off a minor kludge in GDAL's
-        # HFA driver. By default, it will check any Transverse Mercator
-        # projection, and if its parameters match a standard UTM zone, it
-        # re-states the projection as literal UTM. This was originally because
-        # Imagine was not good at matching equivalent projections. This is no
-        # longer true, and we choose to disable that behaviour by default.
-        if DEFAULTDRIVERNAME == "HFA":
-            DEFAULTCREATIONOPTIONS = ['COMPRESSED=YES', 'IGNOREUTM=YES']
-        else:
-            DEFAULTCREATIONOPTIONS = []
-    
-    # In the new paradigm, default creation options are specific to each driver, and
-    # are loaded into a dictionary
-    global dfltDriverOptions
-    dfltDriverOptions = {}
-    # Start with the old generic default options, applied to the default driver
-    dfltDriverOptions[DEFAULTDRIVERNAME] = DEFAULTCREATIONOPTIONS
-    # Load some others which we wish to have as defaults, even if not set by the environment
-    dfltDriverOptions['GTiff'] = ['TILED=YES', 'COMPRESS=DEFLATE',
-        'INTERLEAVE=BAND', 'BIGTIFF=IF_SAFER']
-    # Now load any which are specified by environment variables, of the
-    # form RIOS_DFLT_CREOPT_<drivername>
-    driverOptVarPrefix = 'RIOS_DFLT_CREOPT_'
-    for varname in os.environ:
-        if varname.startswith(driverOptVarPrefix):
-            drvrName = varname[len(driverOptVarPrefix):]
-            optionsStr = os.getenv(varname)
-            dfltDriverOptions[drvrName] = optionsStr.split()
-
-
-setDefaultDriver()
+from . import const
 
 
 def writeBlock(gdalOutObjCache, blockDefn, outfiles, outputs, controls,
@@ -151,7 +83,7 @@ def openOutfile(symbolicName, filename, controls, arr, workinggrid):
     creationoptions = controls.getOptionForImagename('creationoptions',
         symbolicName)
     if creationoptions is None:
-        creationoptions = dfltDriverOptions.get(driverName, [])
+        creationoptions = const.dfltDriverOptions.get(driverName, [])
     doubleCheckCreationOptions(driverName, creationoptions, controls,
         workinggrid)
 

--- a/rios/pixelgrid.py
+++ b/rios/pixelgrid.py
@@ -23,7 +23,7 @@ reference grid.
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from . import imageio
+from . import const
 from . import rioserrors
 from . import fileinfo
 from osgeo import osr
@@ -346,7 +346,7 @@ class PixelGridDefn(object):
         return snappedVal
 
 
-def findCommonRegion(gridList, refGrid, combine=imageio.INTERSECTION):
+def findCommonRegion(gridList, refGrid, combine=const.INTERSECTION):
     """
     Returns a PixelGridDefn for the combination of all the grids 
     in the given gridList. The output grid is in the same coordinate 
@@ -356,7 +356,7 @@ def findCommonRegion(gridList, refGrid, combine=imageio.INTERSECTION):
     or BOUNDS_FROM_REFERENCE is performed. 
     
     """
-    if combine == imageio.BOUNDS_FROM_REFERENCE:
+    if combine == const.BOUNDS_FROM_REFERENCE:
         newGrid = refGrid
     else:
         newGrid = None
@@ -367,9 +367,9 @@ def findCommonRegion(gridList, refGrid, combine=imageio.INTERSECTION):
             if newGrid is None:
                 newGrid = grid
             else:
-                if combine == imageio.INTERSECTION:
+                if combine == const.INTERSECTION:
                     newGrid = newGrid.intersection(grid)
-                elif combine == imageio.UNION:
+                elif combine == const.UNION:
                     newGrid = newGrid.union(grid)
         
     return newGrid


### PR DESCRIPTION
This began as part of preparing to support Zarr format rasters. The per-driver check on overview support (in `calcstats.py`) needed suitable creation options for Zarr (because Zarr V2 does not do overviews), but the default creation options are in `imagewriter.py`. This created a circular import, so I have moved the setup of default creation options into a separate module, `const.py.` 

The intention is that this new file can hold any constant values which might be needed across several modules, avoiding any future circular import problems. Not sure how much of this there will ever be, but still. 

I have also moved the definitions of INTERSECTION, UNION, BOUNDS_FROM_REFERENCE, which were the last remaining important things in `imageio.py`. Places which imported these symbols from imageio.py now import them from const.py, but they are also imported into imageio.py for backward compatibility, in case anyone was getting them from there.

Generally, users should be importing all such symbols from applier.py, so they do not ever need to know about the various other modules.