### PR TITLE
Simplify the bounds of reprojection VRT

### DIFF
--- a/rios/imagereader.py
+++ b/rios/imagereader.py
@@ -276,40 +276,8 @@ def openForWorkingGrid(filename, workinggrid, fileInfo, controls,
 
         srcProj = specialProjFixes(fileInfo.projection)
         dstProj = specialProjFixes(workinggrid.projection)
-        if gdalVersion >= VersionObj('3.8.0'):
-            # We restrict the extent of the reprojection VRT to the reprojected
-            # extent of the underlying raster
-            corners = fileInfo.getCorners(outWKT=dstProj)
-            (ul_x, ul_y, ur_x, ur_y, lr_x, lr_y, ll_x, ll_y) = corners
-            (xRes, yRes) = (workinggrid.xRes, workinggrid.yRes)
-            xMin = min(ul_x, ll_x) - xRes
-            xMax = max(ur_x, lr_x) + xRes
-            yMin = min(ll_y, lr_y) - yRes
-            yMax = max(ul_y, ur_y) + yRes
-            xMin = PixelGridDefn.snapToGrid(xMin, workinggrid.xMin, xRes)
-            xMax = PixelGridDefn.snapToGrid(xMax, workinggrid.xMin, xRes)
-            yMin = PixelGridDefn.snapToGrid(yMin, workinggrid.yMin, yRes)
-            yMax = PixelGridDefn.snapToGrid(yMax, workinggrid.yMin, yRes)
-            filePixGrid = PixelGridDefn(projection=dstProj, xMin=xMin, yMin=yMin,
-                xMax=xMax, yMax=yMax, xRes=xRes, yRes=yRes)
-
-            # Make a pixgrid of the intersection between file grid and
-            # working grid
-            intersectGrid = workinggrid.intersection(filePixGrid)
-
-            # The bounds of the VRT are from the intersection
-            outBounds = (intersectGrid.xMin, intersectGrid.yMin,
-                intersectGrid.xMax, intersectGrid.yMax)
-        else:
-            # In older versions of GDAL, there is some subtle interaction with
-            # VRT and block size and extent, which can lead to severe
-            # performance degradation when the above approach is used to limit
-            # the extent of the VRT. So, for those older GDAL versions, we use
-            # a simpler approach where the VRT extent is always identical
-            # to the working grid. This also has a small performance penalty,
-            # but much less severe, and so seems safer.
-            outBounds = (workinggrid.xMin, workinggrid.yMin,
-                workinggrid.xMax, workinggrid.yMax)
+        outBounds = (workinggrid.xMin, workinggrid.yMin,
+            workinggrid.xMax, workinggrid.yMax)
 
         # Work out what null value(s) to use, honouring anything set
         # with controls.setInputNoDataValue().


### PR DESCRIPTION
The current code for calculating the bounds of a reprojection VRT attempts to restrict the VRT against the extent of the underlying file in its own coordinate system. This turns out to create problems when the underlying projection is well outside the safe use area of the working projection.

To avoid these problems, just use the simpler option of making the VRT extent always identical to the working grid extent. I had earlier thought there was a performance benefit to the more complicated approach, but it appears not. This is probably because GDAL's VRT code is much cleverer than I am.

As discussed in #204 
