### PR TITLE
Reproject PixelGridDefn object using dense bounding box edges (not just corners)

### DIFF
--- a/rios/pixelgrid.py
+++ b/rios/pixelgrid.py
@@ -22,6 +22,7 @@ reference grid.
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import numpy
 
 from . import const
 from . import rioserrors
@@ -263,9 +264,24 @@ class PixelGridDefn(object):
         
     def reproject(self, targetGrid):
         """
-        Returns a new instance which is the reprojection
-        of self to be in the same projection and pixel size
-        as targetGrid
+        Returns a new instance which is the reprojection of self to be
+        in the same projection and pixel size as targetGrid.
+
+        The bounding box is created by reprojecting the densely-sampled
+        edges, so that the extent will fully cover reprojections which curve
+        an edge outwards from the source bounding box. For small extents
+        this is usually trivial, but for large extents it can become quite
+        important.
+
+        The edge curves are sampled at many points along each edge, which
+        obviously does not absolutely guarantee the fullest extent. Ideally one
+        would do a gradient search to find the local extreme point along the
+        edge, but I was not convinced that there could never be multiple local
+        extremes, depending on the combination of projections and extents
+        involved, so I concluded that a fairly dense sampling was sufficiently
+        good. However, it should be noted that a large region, with a suitable
+        combination of projections, may still clip off small parts of the
+        bounding box.
         
         """
         srSelf = osr.SpatialReference(str(self.projection))
@@ -273,28 +289,55 @@ class PixelGridDefn(object):
         srTarget = osr.SpatialReference(str(targetGrid.projection))
         fileinfo.preventGdal3axisSwap(srTarget)
         t = osr.CoordinateTransformation(srSelf, srTarget)
-        
-        (tl_x, tl_y, z) = t.TransformPoint(self.xMin, self.yMax)
-        (bl_x, bl_y, z) = t.TransformPoint(self.xMin, self.yMin)
-        (tr_x, tr_y, z) = t.TransformPoint(self.xMax, self.yMax)
-        (br_x, br_y, z) = t.TransformPoint(self.xMax, self.yMin)
-        
-        xMin = min(tl_x, bl_x)
-        xMax = max(tr_x, br_x)
-        yMin = min(bl_y, br_y)
-        yMax = max(tl_y, tr_y)
+
+        # Make dense lines for each of the 4 edges, with n points on each edge
+        n = 101
+        (xMin, xMax, yMin, yMax) = (self.xMin, self.xMax, self.yMin, self.yMax)
+        edge1 = self.densifyInterval(xMin, yMax, xMax, yMax, n)
+        edge2 = self.densifyInterval(xMax, yMin, xMax, yMax, n)
+        edge3 = self.densifyInterval(xMin, yMin, xMax, yMin, n)
+        edge4 = self.densifyInterval(xMin, yMin, xMin, yMax, n)
+        allEdges = numpy.concatenate((edge1, edge2, edge3, edge4), axis=0)
+
+        # Reproject dense outline into target projection
+        allEdges_tgt = t.TransformPoints(allEdges)
+        allEdges_tgt = numpy.array(allEdges_tgt)
+
+        # Find the bounding box
+        xMin_tgt = allEdges_tgt[:, 0].min()
+        xMax_tgt = allEdges_tgt[:, 0].max()
+        yMin_tgt = allEdges_tgt[:, 1].min()
+        yMax_tgt = allEdges_tgt[:, 1].max()
         
         # Snap bounds to align with those in target grid
-        xMin = self.snapToGrid(xMin, targetGrid.xMin, targetGrid.xRes)
-        xMax = self.snapToGrid(xMax, targetGrid.xMin, targetGrid.xRes)
-        yMin = self.snapToGrid(yMin, targetGrid.yMin, targetGrid.yRes)
-        yMax = self.snapToGrid(yMax, targetGrid.yMin, targetGrid.yRes)
+        xMin_tgt = self.snapToGrid(xMin_tgt, targetGrid.xMin, targetGrid.xRes)
+        xMax_tgt = self.snapToGrid(xMax_tgt, targetGrid.xMin, targetGrid.xRes)
+        yMin_tgt = self.snapToGrid(yMin_tgt, targetGrid.yMin, targetGrid.yRes)
+        yMax_tgt = self.snapToGrid(yMax_tgt, targetGrid.yMin, targetGrid.yRes)
         
         # Construct a new pixel grid object
-        newPixelGrid = PixelGridDefn(xMin=xMin, xMax=xMax, yMin=yMin, yMax=yMax, 
-            xRes=targetGrid.xRes, yRes=targetGrid.yRes, projection=targetGrid.projection)
+        newPixelGrid = PixelGridDefn(xMin=xMin_tgt, xMax=xMax_tgt,
+            yMin=yMin_tgt, yMax=yMax_tgt, xRes=targetGrid.xRes,
+            yRes=targetGrid.yRes, projection=targetGrid.projection)
         
         return newPixelGrid
+
+    @staticmethod
+    def densifyInterval(x1, y1, x2, y2, n):
+        """
+        Create a densely sampled sequence of points along an interval, given
+        the end points of the interval, (x1, y1) and (x2, y2). The total number
+        of points desired is n, including the given end points.
+
+        This is an internal utility function, used by reproject().
+
+        Returns a single array of shape (n, 2), with x in the first column.
+        """
+        nn = n * 1j
+        x = numpy.mgrid[x1:x2:nn].reshape((n, 1))
+        y = numpy.mgrid[y1:y2:nn].reshape((n, 1))
+        xy = numpy.concatenate((x, y), axis=1)
+        return xy
     
     def getDimensions(self):
         """

--- a/rios/riostests/riostestutils.py
+++ b/rios/riostests/riostestutils.py
@@ -285,6 +285,11 @@ def testAll():
     if not ok:
         failureCount += 1
 
+    from . import testreprojcurves
+    ok = testreprojcurves.run()
+    if not ok:
+        failureCount += 1
+
     from . import testsetinputnull
     ok = testsetinputnull.run()
     if not ok:

--- a/rios/riostests/testreprojcurves.py
+++ b/rios/riostests/testreprojcurves.py
@@ -1,0 +1,153 @@
+"""
+Test reprojection of input file, with particular attention to the edges
+of the working grid which can be projected into a curve.
+
+"""
+# This file is part of RIOS - Raster I/O Simplification
+# Copyright (C) 2012  Sam Gillingham, Neil Flood
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import numpy
+from osgeo import gdal, osr
+from rios import applier
+
+from rios.riostests import riostestutils
+
+
+TESTNAME = "TESTREPROJCURVES"
+
+
+def run():
+    """
+    Run the test
+    """
+    riostestutils.reportStart(TESTNAME)
+
+    allOK = True
+
+    circleVal = 100
+    circleLLfile = createCircleImg(circleVal)
+    circleGdal = reprojGdal(circleLLfile)
+    circleRios = reprojRios(circleLLfile, circleGdal)
+
+    ok = compareCircles(circleGdal, circleRios, circleVal)
+
+    allOK = allOK and ok
+    
+    # Clean up
+    for filename in [circleLLfile, circleGdal, circleRios]:
+        riostestutils.removeRasterFile(filename)
+
+    if allOK:
+        riostestutils.report(TESTNAME, "Passed")
+
+    return allOK
+
+
+def createCircleImg(circleVal):
+    """
+    Create an input image in lat/long, with a circle embedded. The extent
+    is about the width of Australia, and the circle is near the top
+    of Australia, up against the top edge of the extent. This edge will
+    curve when reprojected into Australian Albers, and if not handled 
+    properly, the working grid edge could clip off the top part of the circle.
+
+    Return the name of the file.
+
+    """
+    drvr = gdal.GetDriverByName('HFA')
+    (left, right, bottom, top) = (112.0, 154.0, -15.0, -10.0)
+    (xRes, yRes) = (0.1, 0.1)
+    (width, height) = (right - left, top - bottom)
+    (nrows, ncols) = (int(height / yRes), int(width / xRes))
+
+    filename = 'circle.img'
+    ds = drvr.Create(filename, ncols, nrows, 1, eType=gdal.GDT_Byte,
+                     options=["COMPRESS=YES"])
+    srLL = osr.SpatialReference()
+    srLL.ImportFromEPSG(4326)
+    ds.SetSpatialRef(srLL)
+    ds.SetGeoTransform((left, xRes, 0.0, top, 0.0, -yRes))
+    band = ds.GetRasterBand(1)
+
+    (row, col) = numpy.mgrid[:nrows, :ncols]
+    circleMask = (((row - nrows / 2)**2 + (col - ncols / 2)**2) < (nrows / 2)**2)
+    arr = numpy.full((nrows, ncols), 50, dtype=numpy.uint8)
+    arr[circleMask] = circleVal
+    band.WriteArray(arr)
+
+    return filename
+
+
+def reprojGdal(circleLLfile):
+    """
+    Reproject to AustAlbers using gdalwarp
+    """
+    circleGdal = "circleGdal.img"
+    srAlbers = osr.SpatialReference()
+    srAlbers.ImportFromEPSG(3577)
+    srAlbers.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+
+    outRes = 10000  # 10km pixel size
+    warpOptions = gdal.WarpOptions(format='HFA', creationOptions=["COMPRESS=YES"],
+                                   targetAlignedPixels=True, dstSRS=srAlbers,
+                                   xRes=outRes, yRes=outRes)
+    gdal.Warp(circleGdal, circleLLfile, options=warpOptions)
+    return circleGdal
+
+
+def reprojRios(circleLLfile, circleGdal):
+    """
+    Reproject the input file to match the GDAL warped output.
+    """
+    circleRiosfile = "circle_riosalbers.img"
+    infiles = applier.FilenameAssociations()
+    outfiles = applier.FilenameAssociations()
+    controls = applier.ApplierControls()
+
+    infiles.circle = circleLLfile
+    outfiles.circle_albers = "circle_riosalbers.img"
+    controls.setReferenceImage(circleGdal)
+    applier.apply(doNothing, infiles, outfiles, controls=controls)
+
+    return circleRiosfile
+
+
+def doNothing(info, inputs, outputs):
+    """
+    Called from RIOS
+    """
+    outputs.circle_albers = inputs.circle
+
+
+def compareCircles(circleGdal, circleRios, circleVal):
+    """
+    Count how many pixels of circleVal appear in each of the two images. They
+    should be the same. Return False if not.
+    """
+    dsGdal = gdal.Open(circleGdal)
+    dsRios = gdal.Open(circleRios)
+    arrGdal = dsGdal.GetRasterBand(1).ReadAsArray()
+    arrRios = dsRios.GetRasterBand(1).ReadAsArray()
+    gdalCount = numpy.count_nonzero(arrGdal == circleVal)
+    riosCount = numpy.count_nonzero(arrRios == circleVal)
+    ok = (gdalCount == riosCount)
+
+    if not ok:
+        msg = f"Pixel count mis-match. {gdalCount} != {riosCount}"
+        riostestutils.report(TESTNAME, msg)
+
+    return ok
+


### PR DESCRIPTION
Currently, footprint intersections etc., are calculated using reprojected corners of pixel grid bounding boxes. For some combinations of projection, on sufficiently large areas, the lack of the curved edges can result in clipping of the reprojected bounding box in ways which can lose data.

This PR implements reprojection of these bounding boxes using a fairly dense sampling of points along the edges, allowing the curve to be represented. This largely eliminates the problem, at least up to the level of the much shorter straight lines between sample points.

The following images demonstrate the problem and solution. The first circle is in lat/long coordinates. It is centred at (133E, 12.5S), i.e. in northern Australia. The radius is 2.5 degrees. The image is 42 degrees wide (roughly the width of Australia), which gives a long enough edge for the curvature to be significant.
<img width="1236" height="164" alt="circle_latlong" src="https://github.com/user-attachments/assets/c544d021-ce76-4e1d-812b-3aab9924ece3" />

The second is output from RIOS, without this PR. The working grid was in Australian Albers projection (3577), which curves the top edge to the north. Since the bounding box of the working grid does not allow for this curvature, the top of the circle is clipped off.
<img width="1236" height="164" alt="circle_albers_clipped" src="https://github.com/user-attachments/assets/27fe3d04-9d59-4e3e-b782-cd8d3a08842e" />

The third output is the same, but using the new implementation. As desired, the circle is not clipped.
<img width="1236" height="164" alt="circle_albers_notclipped" src="https://github.com/user-attachments/assets/8bbfade0-4111-4df9-9b55-18bb6adf2084" />

Finally, this is the same image reprojected by `gdalwarp`, showing a very good match.
<img width="1236" height="164" alt="circle_gdalalbers" src="https://github.com/user-attachments/assets/fea0992f-727b-4aac-947c-c682c03b672f" />
