### PR TITLE
Ignore large, all-surrounding input extents for intersection calculation

### DIFF
--- a/rios/imagereader.py
+++ b/rios/imagereader.py
@@ -234,20 +234,26 @@ def openForWorkingGrid(filename, workinggrid, fileInfo, controls,
         vectorPixgrid = PixelGridDefn(projection=projection,
             xMin=xMin, xMax=xMax, yMin=yMin, yMax=yMax,
             xRes=xRes_vec, yRes=yRes_vec)
-        gridList = [workinggrid, vectorPixgrid]
-        try:
-            commonRegion = findCommonRegion(gridList, vectorPixgrid,
-                combine=const.INTERSECTION)
-        except rioserrors.IntersectionError:
-            commonRegion = None
+        if vectorPixgrid.surrounds(workinggrid):
+            outBounds = (workinggrid.xMin, workinggrid.yMin,
+                workinggrid.xMax, workinggrid.yMax)
+        else:
+            gridList = [workinggrid, vectorPixgrid]
+            try:
+                commonRegion = findCommonRegion(gridList, vectorPixgrid,
+                    combine=const.INTERSECTION)
+            except rioserrors.IntersectionError:
+                commonRegion = None
+            if commonRegion is not None:
+                outBounds = (commonRegion.xMin, commonRegion.yMin,
+                    commonRegion.xMax, commonRegion.yMax)
+            else:
+                # No intersection, just rasterize a single pixel
+                outBounds = (wgCtrX, wgCtrY, wgCtrX + xRes_vec, wgCtrY + yRes_vec)
+
         dtype = controls.getOptionForImagename('vectordatatype', symbolicName)
         gdalDtype = gdal_array.NumericTypeCodeToGDALTypeCode(dtype)
         gtiffOptions = ['TILED=YES', 'COMPRESS=DEFLATE', 'BIGTIFF=IF_SAFER']
-        if commonRegion is not None:
-            outBounds = (commonRegion.xMin, commonRegion.yMin,
-                commonRegion.xMax, commonRegion.yMax)
-        else:
-            outBounds = (wgCtrX, wgCtrY, wgCtrX + xRes_vec, wgCtrY + yRes_vec)
         vecNull = controls.getOptionForImagename('vectornull', symbolicName)
         burnattribute = controls.getOptionForImagename('burnattribute',
                 symbolicName)

--- a/rios/pixelgrid.py
+++ b/rios/pixelgrid.py
@@ -262,16 +262,18 @@ class PixelGridDefn(object):
         geotransform = (self.xMin, self.xRes, 0.0, self.yMax, 0.0, -self.yRes)
         return geotransform
         
-    def reproject(self, targetGrid):
+    def reproject(self, targetGrid, snap=True):
         """
         Returns a new instance which is the reprojection of self to be
-        in the same projection and pixel size as targetGrid.
+        in the same projection and pixel size as targetGrid. By default,
+        the new coordinates are snapped to a multiple of pixel size, but
+        this can be disabled with snap=False.
 
         The bounding box is created by reprojecting the densely-sampled
         edges, so that the extent will fully cover reprojections which curve
         an edge outwards from the source bounding box. For small extents
-        this is usually trivial, but for large extents it can become quite
-        important.
+        this is usually trivial, but for large extents it can become
+        important (new in 2.1.0, previously only corners were used).
 
         The edge curves are sampled at many points along each edge, which
         obviously does not absolutely guarantee the fullest extent. Ideally one
@@ -310,10 +312,11 @@ class PixelGridDefn(object):
         yMax_tgt = allEdges_tgt[:, 1].max()
         
         # Snap bounds to align with those in target grid
-        xMin_tgt = self.snapToGrid(xMin_tgt, targetGrid.xMin, targetGrid.xRes)
-        xMax_tgt = self.snapToGrid(xMax_tgt, targetGrid.xMin, targetGrid.xRes)
-        yMin_tgt = self.snapToGrid(yMin_tgt, targetGrid.yMin, targetGrid.yRes)
-        yMax_tgt = self.snapToGrid(yMax_tgt, targetGrid.yMin, targetGrid.yRes)
+        if snap:
+            xMin_tgt = self.snapToGrid(xMin_tgt, targetGrid.xMin, targetGrid.xRes)
+            xMax_tgt = self.snapToGrid(xMax_tgt, targetGrid.xMin, targetGrid.xRes)
+            yMin_tgt = self.snapToGrid(yMin_tgt, targetGrid.yMin, targetGrid.yRes)
+            yMax_tgt = self.snapToGrid(yMax_tgt, targetGrid.yMin, targetGrid.yRes)
         
         # Construct a new pixel grid object
         newPixelGrid = PixelGridDefn(xMin=xMin_tgt, xMax=xMax_tgt,
@@ -321,6 +324,26 @@ class PixelGridDefn(object):
             yRes=targetGrid.yRes, projection=targetGrid.projection)
         
         return newPixelGrid
+
+    def surrounds(self, other):
+        """
+        Return True if self completely surrounds other.
+
+        The check is just on all corners, and is False when any of the
+        corners of other lie outside the min/max bounds of self.
+
+        """
+        surr = True
+        if other.xMin < self.xMin or other.xMin > self.xMax:
+            surr = False
+        if other.xMax < self.xMin or other.xMax > self.xMax:
+            surr = False
+        if other.yMin < self.yMin or other.yMin > self.yMax:
+            surr = False
+        if other.yMax < self.yMin or other.yMax > self.yMax:
+            surr = False
+
+        return surr
 
     @staticmethod
     def densifyInterval(x1, y1, x2, y2, n):
@@ -402,6 +425,9 @@ def findCommonRegion(gridList, refGrid, combine=const.INTERSECTION):
     if combine == const.BOUNDS_FROM_REFERENCE:
         newGrid = refGrid
     else:
+        if combine == const.INTERSECTION:
+            gridList = removeSurrounding(gridList)
+
         newGrid = None
         for grid in gridList:
             if not refGrid.alignedWith(grid):
@@ -416,6 +442,53 @@ def findCommonRegion(gridList, refGrid, combine=const.INTERSECTION):
                     newGrid = newGrid.union(grid)
         
     return newGrid
+
+
+def removeSurrounding(gridList):
+    """
+    Check a list of PixelGridDefn objects for any which completely surround
+    all of the others. If that is true, the outer one can never contribute to
+    an intersection calculation, so it is removed.
+
+    The check is done in geographic coordinates (i.e. lat/long), because
+    any other projection can be validly transformed into this.
+
+    Return a new list with all such outer pixgrids removed.
+
+    """
+    # Create a generic pixelgrid of global lat/long
+    srLL = osr.SpatialReference(epsg=4326)
+    srLL.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    wkt = srLL.ExportToWkt()
+    llGrid = PixelGridDefn(projection=wkt, xMin=-180.0, xMax=180.0,
+        yMin=-90.0, yMax=90.0, xRes=1.0, yRes=1.0)
+
+    numGrids = len(gridList)
+    keep = numpy.ones(numGrids, dtype=bool)
+    gridListLL = [grid.reproject(llGrid, snap=False) for grid in gridList]
+
+    # Iterate the check, removing one at a time, until we do not
+    # remove anything. Always keep at least one grid.
+    changed = True
+    while changed and numpy.count_nonzero(keep) > 1:
+        changed = False
+        # Check i-th grid against all others
+        for i in range(numGrids):
+            if keep[i] and numpy.count_nonzero(keep) > 1:
+                surroundsAll = True
+                for j in range(numGrids):
+                    if i != j and keep[j]:
+                        gridLL = gridListLL[i]
+                        otherLL = gridListLL[j]
+                        if not gridLL.surrounds(otherLL):
+                            surroundsAll = False
+
+                if surroundsAll:
+                    keep[i] = False
+                    changed = True
+
+    newGridList = [gridList[i] for i in range(numGrids) if keep[i]]
+    return newGridList
 
 
 def pixelGridFromFile(filename):

--- a/rios/pixelgrid.py
+++ b/rios/pixelgrid.py
@@ -266,8 +266,8 @@ class PixelGridDefn(object):
         """
         Returns a new instance which is the reprojection of self to be
         in the same projection and pixel size as targetGrid. By default,
-        the new coordinates are snapped to a multiple of pixel size, but
-        this can be disabled with snap=False.
+        the new coordinates are snapped to a multiple of the target pixel
+        size, but this can be disabled with snap=False.
 
         The bounding box is created by reprojecting the densely-sampled
         edges, so that the extent will fully cover reprojections which curve

--- a/rios/riostests/testfootprint.py
+++ b/rios/riostests/testfootprint.py
@@ -23,7 +23,9 @@ correct answer fairly simple.
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import numpy
+from osgeo import osr
 from rios import applier, fileinfo
+from rios.pixelgrid import removeSurrounding, PixelGridDefn
 
 from . import riostestutils
 
@@ -76,6 +78,9 @@ def run():
 
     for fn in [ramp1, ramp2, outimg]:
         riostestutils.removeRasterFile(fn)
+
+    ok = testRemoveSurrounding()
+    allOK = allOK and ok
     
     if allOK:
         riostestutils.report(TESTNAME, "Passed")
@@ -136,3 +141,89 @@ def makeExtentTuple(info):
     """
     extent = (info.xMin, info.xMax, info.yMin, info.yMax)
     return extent
+
+
+def testRemoveSurrounding():
+    """
+    Test a bunch of scenarios for removal of large surrounding bounding boxes
+    """
+    # Some SpatialReference objects for different map projections
+    sr4326 = osr.SpatialReference(epsg=4326)
+    sr4326.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    wkt4326 = sr4326.ExportToWkt()
+
+    sr3577 = osr.SpatialReference(epsg=3577)
+    sr3577.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    wkt3577 = sr3577.ExportToWkt()
+
+    sr32756 = osr.SpatialReference(epsg=32756)
+    sr32756.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    wkt32756 = sr32756.ExportToWkt()
+
+    # Some pixel grids with varying extents and projections
+    pgGlobal4326 = PixelGridDefn(projection=wkt4326, xMin=-180.0, xMax=180.0,
+        yMin=-90.0, yMax=90.0, xRes=1.0, yRes=1.0)
+    ctrAus3577 = (300000, -3000000)
+    halfSide = 400000
+    pgCtr3577 = PixelGridDefn(projection=wkt3577, xRes=100.0, yRes=100.0,
+        xMin=(ctrAus3577[0] - halfSide), xMax=(ctrAus3577[0] + halfSide),
+        yMin=(ctrAus3577[1] - halfSide), yMax=(ctrAus3577[1] + halfSide))
+    pgCtrSmall3577 = PixelGridDefn(projection=wkt3577, xRes=100.0, yRes=100.0,
+        xMin=(ctrAus3577[0] - halfSide / 2), xMax=(ctrAus3577[0] + halfSide / 2),
+        yMin=(ctrAus3577[1] - halfSide / 2), yMax=(ctrAus3577[1] + halfSide / 2))
+    pgCtrOffset3577 = PixelGridDefn(projection=wkt3577, xRes=100.0, yRes=100.0,
+        xMin=ctrAus3577[0], xMax=(ctrAus3577[0] + 2 * halfSide),
+        yMin=(ctrAus3577[1] - 2 * halfSide), yMax=ctrAus3577[1])
+    ctrUtm56 = (500000, 4200000)
+    pgBris32756 = PixelGridDefn(projection=wkt32756, xRes=100.0, yRes=100.0,
+        xMin=(ctrUtm56[0] - halfSide), xMax=(ctrUtm56[0] + halfSide),
+        yMin=(ctrUtm56[1] - halfSide), yMax=(ctrUtm56[1] + halfSide))
+
+    allOK = True
+    # Do some removals, and check the answers
+    pglist = removeSurrounding(
+        [pgGlobal4326, pgCtr3577, pgCtrOffset3577])
+    ok = checkGridLists(pglist, [pgCtr3577, pgCtrOffset3577], 'A')
+    allOK = allOK and ok
+
+    pglist = removeSurrounding(
+        [pgGlobal4326, pgCtrSmall3577, pgCtr3577, pgCtrOffset3577])
+    ok = checkGridLists(pglist, [pgCtr3577, pgCtrSmall3577, pgCtrOffset3577], 'B')
+    allOK = allOK and ok
+
+    pglist = removeSurrounding([pgCtr3577, pgCtrOffset3577])
+    ok = checkGridLists(pglist, [pgCtr3577, pgCtrOffset3577], 'C')
+    allOK = allOK and ok
+
+    pglist = removeSurrounding([pgGlobal4326, pgBris32756])
+    ok = checkGridLists(pglist, [pgBris32756], 'D')
+    allOK = allOK and ok
+
+    pglist = removeSurrounding([pgBris32756])
+    ok = checkGridLists(pglist, [pgBris32756], 'E')
+    allOK = allOK and ok
+
+    return allOK
+
+
+def checkGridLists(pglist1, pglist2, scenario):
+    """
+    Check that two grid lists match. If not, print the difference
+    """
+    match = True
+    pgset1 = set([str(pg) for pg in pglist1])
+    pgset2 = set([str(pg) for pg in pglist2])
+    diff1 = (pgset1 - pgset2)
+    diff2 = (pgset2 - pgset1)
+    if pgset1 != pgset2:
+        msg = f"removeSurrounding, scenario {scenario}"
+        riostestutils.report(TESTNAME, msg)
+        if len(diff1) > 0:
+            msg = f"Grids not removed. {diff1}"
+            riostestutils.report(TESTNAME, msg)
+        if len(diff2) > 0:
+            msg = f"Grids removed. {diff2}"
+            riostestutils.report(TESTNAME, msg)
+
+        match = False
+    return match


### PR DESCRIPTION
When calculating intersections for the working grid, a very large input extent which completely surrounds all others contributes nothing to the intersection. However, if sufficiently large, its bounds may not be valid to reproject into the working grid projection, potentially causing errors. This problem is discussed in #204.

To avoid this, a simpler check can be done first, in geographic coordinates (lat/long), to see if one extent completely surrounds all others, and it can be removed before calculating the intersection bounding box. This makes it much easier to intersect with a global background dataset, while still only working in the intersection of the local inputs of interest.

This is only applied for INTERSECTION, it makes no sense for UNION.

@gillins, @petescarth. I have added some tests for this procedure, but I would love to see some real-life tests to make sure I have not broken anything.