### PR TITLE
Use ast.literal_eval instead of eval, as recommended for security reasons

### DIFF
--- a/rios/fileinfo.py
+++ b/rios/fileinfo.py
@@ -22,6 +22,7 @@ information in via the otherargs parameter.
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from __future__ import print_function
+import ast
 
 import numpy
 from osgeo import gdal
@@ -252,7 +253,7 @@ class ImageLayerStats(object):
         if self.histoCounts is None and 'STATISTICS_HISTOBINVALUES' in metadata:
             histoString = metadata['STATISTICS_HISTOBINVALUES']
             histoStringList = [c for c in histoString.split('|') if len(c) > 0]
-            counts = [eval(c) for c in histoStringList]
+            counts = [ast.literal_eval(c) for c in histoStringList]
             self.histoCounts = numpy.array(counts)
     
     @staticmethod
@@ -260,7 +261,7 @@ class ImageLayerStats(object):
         "Return eval(item) by key, or None if not present"
         item = None
         if key in metadata:
-            item = eval(metadata[key])
+            item = ast.literal_eval(metadata[key])
         return item
     
     def __str__(self):

--- a/rios/riostests/medianConcTest.py
+++ b/rios/riostests/medianConcTest.py
@@ -7,6 +7,7 @@ a part of the standard test suite, but just for use during development.
 import argparse
 import json
 import time
+import ast
 
 import numpy
 try:
@@ -109,7 +110,7 @@ def main():
         cwKind = CW_NONE
         computeWorkersRead=False
         if cmdargs.numcomputeworkers > 0:
-            cwKind = eval("CW_{}".format(cmdargs.kind.upper()))
+            cwKind = ast.literal_eval("CW_{}".format(cmdargs.kind.upper()))
         if cwKind == CW_AWSBATCH:
             # This does not always have to be True, but for our tests it
             # is the correct choice

--- a/rios/structures.py
+++ b/rios/structures.py
@@ -31,6 +31,7 @@ import queue
 import tempfile
 import traceback
 import shutil
+import ast
 
 import numpy
 from osgeo import gdal
@@ -1013,7 +1014,7 @@ class NetworkDataChannel:
             self.mgr.connect()
 
             # Get the proxy objects.
-            self.workerInitData = cloudpickle.loads(eval(str(
+            self.workerInitData = cloudpickle.loads(ast.literal_eval(str(
                 self.mgr.get_workerdata())))
             self.inBlockBuffer = self.mgr.get_inblockbuffer()
             self.outBlockBuffer = self.mgr.get_outblockbuffer()


### PR DESCRIPTION
The bandit security scanner recommends against use of `eval()`, and in favour of `ast.literal_eval()` instead. The latter will only evaluate literal values, not variables or expressions or statements of any kind, and so is a better guard against malicious insertion of executable code.

Just trying to be thorough.