### PR TITLE
Stronger direct pyramids check, to cope with Zarr output driver

### DIFF
--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -490,8 +490,6 @@ class SinglePassManager:
         for (symbolicName, seqNum, filename) in outfiles:
             driverName = controls.getOptionForImagename(
                 'drivername', symbolicName)
-            if driverName.upper() == "ZARR":
-                driverSupportsDirectPyramids[driverName] = False
             if driverName not in driverSupportsDirectPyramids:
                 drvr = gdal.GetDriverByName(driverName)
                 options = controls.getOptionForImagename('creationoptions',
@@ -509,24 +507,27 @@ class SinglePassManager:
                 ds = drvr.Create(imgfile, ncols, nrows, 1, gdal.GDT_Byte,
                     options=options)
                 band = ds.GetRasterBand(1)
-                ds.BuildOverviews(overviewlist=[2])
-                band.WriteArray(arr)
-                band_ov = band.GetOverview(0)
-                arr_ov = arr[::2, ::2]
-                band_ov.WriteArray(arr_ov)
-                del band_ov, band, ds
+                try:
+                    ds.BuildOverviews(overviewlist=[2])
+                    band.WriteArray(arr)
+                    band_ov = band.GetOverview(0)
+                    arr_ov = arr[::2, ::2]
+                    band_ov.WriteArray(arr_ov)
+                    del band_ov, band, ds
 
-                # Now read back the overview array
-                ds = gdal.Open(imgfile)
-                band = ds.GetRasterBand(1)
-                band_ov = band.GetOverview(0)
-                arr_sub2 = band_ov.ReadAsArray()
-                del band_ov, band, ds
-                drvr.Delete(imgfile)
+                    # Now read back the overview array
+                    ds = gdal.Open(imgfile)
+                    band = ds.GetRasterBand(1)
+                    band_ov = band.GetOverview(0)
+                    arr_sub2 = band_ov.ReadAsArray()
+                    del band_ov, band, ds
+                    drvr.Delete(imgfile)
 
-                # If the overview array is full of the fill value, then it works
-                supported = (arr_sub2 == fillVal).all()
-                driverSupportsDirectPyramids[driverName] = supported
+                    # If the overview array is full of the fill value, then it works
+                    supported = (arr_sub2 == fillVal).all()
+                    driverSupportsDirectPyramids[driverName] = supported
+                except Exception:
+                    driverSupportsDirectPyramids[driverName] = False
 
         return driverSupportsDirectPyramids
 

--- a/rios/calcstats.py
+++ b/rios/calcstats.py
@@ -433,7 +433,7 @@ class SinglePassManager:
 
         (nrows, ncols) = workinggrid.getDimensions()
         mindim = min(nrows, ncols)
-        driverSupportsPyramids = self.checkDriverPyramidSupport(outfiles,
+        driverSupportsDirectPyramids = self.checkDriverPyramidSupport(outfiles,
             controls, tmpfileMgr)
 
         for (symbolicName, seqNum, filename) in outfiles:
@@ -457,7 +457,7 @@ class SinglePassManager:
             driverName = controls.getOptionForImagename('drivername',
                 symbolicName)
             self.directPyramidsSupported[symbolicName] = (
-                driverSupportsPyramids[driverName])
+                driverSupportsDirectPyramids[driverName])
 
             self.approxOK[symbolicName] = controls.getOptionForImagename(
                 'approxStats', symbolicName)
@@ -484,13 +484,15 @@ class SinglePassManager:
         support direct writing of pyramid layers. Return a dictionary keyed
         by driver name, with boolean values.
         """
-        driverSupportsPyramids = {}
+        driverSupportsDirectPyramids = {}
         nrows = ncols = 64
         fillVal = 20
         for (symbolicName, seqNum, filename) in outfiles:
             driverName = controls.getOptionForImagename(
                 'drivername', symbolicName)
-            if driverName not in driverSupportsPyramids:
+            if driverName.upper() == "ZARR":
+                driverSupportsDirectPyramids[driverName] = False
+            if driverName not in driverSupportsDirectPyramids:
                 drvr = gdal.GetDriverByName(driverName)
                 options = controls.getOptionForImagename('creationoptions',
                     symbolicName)
@@ -524,9 +526,9 @@ class SinglePassManager:
 
                 # If the overview array is full of the fill value, then it works
                 supported = (arr_sub2 == fillVal).all()
-                driverSupportsPyramids[driverName] = supported
+                driverSupportsDirectPyramids[driverName] = supported
 
-        return driverSupportsPyramids
+        return driverSupportsDirectPyramids
 
     def initFor(self, ds, symbolicName, seqNum, arr):
         """


### PR DESCRIPTION
The GDAL Zarr driver is a work in progress. It now mostly works, but still does not quite support overviews as well as it should. In particular, it raises an exception if used with direct writing of overviews.

In this PR, I have strengthened the check for support of direct pyramid writing, with a try/except. It will now report that Zarr does not support it, without raising an exception. If and when Zarr does support it, the check should (I hope) report this correctly, and so not require any update to work when it is supported.

I also changed the name of the `driverSupportsPyramids` to `driverSupportsDirectPyramids`, to clarify exactly what is being checked.